### PR TITLE
Feature/570 in page and chapter navigation

### DIFF
--- a/spec/chapter_navigation.spec.php
+++ b/spec/chapter_navigation.spec.php
@@ -1,0 +1,93 @@
+<?php
+
+use Kahlan\Arg;
+
+describe(\LongReadPlugin\ChapterNavigation::class, function () {
+    beforeEach(function () {
+        $this->chapterNavigation = new \LongReadPlugin\ChapterNavigation();
+    });
+
+    describe('->getItems()', function () {
+        context('global post is the parent long-read post', function () {
+            it('returns an array of items with the first item as the current post, which will have a null url property', function () {
+                global $post;
+                $post = (object) [
+                    'ID' => 123,
+                    'post_title' => 'Chapter One'
+                ];
+                allow('get_post_parent')->toBeCalled()->andReturn(false);
+                allow('get_posts')->toBeCalled()->andReturn([
+                    (object) [
+                        'ID' => 456,
+                        'post_title' => 'Chapter Two'
+                    ],
+                    (object) [
+                        'ID' => 789,
+                        'post_title' => 'Chapter Three'
+                    ],
+                ]);
+                expect('get_posts')->toBeCalled()->once()->with([
+                    'post_parent' => 123,
+                    'post_type' => 'long-read',
+                    'posts_per_page' => -1,
+                    'orderby' => 'menu_order',
+                    'order' => 'ASC'
+                ]);
+                allow('get_permalink')->toBeCalled()->andReturn('http://chapter-two-link', 'http://chapter-three-link');
+
+                $result = $this->chapterNavigation->getItems();
+
+                expect(count($result))->toEqual(3);
+                expect($result[0]->title)->toEqual('Chapter One');
+                expect($result[0]->url)->toEqual(null);
+                expect($result[1]->title)->toEqual('Chapter Two');
+                expect($result[1]->url)->toEqual('http://chapter-two-link');
+                expect($result[2]->title)->toEqual('Chapter Three');
+                expect($result[2]->url)->toEqual('http://chapter-three-link');
+            });
+        });
+
+        context('global post is a child long-read post', function () {
+            it('returns an array of items with the current post in the appropriate place, and with a null url property', function () {
+                global $post;
+                $post = (object) [
+                    'ID' => 456,
+                    'post_title' => 'Chapter Two'
+                ];
+                $parentPost = (object) [
+                    'ID' => 123,
+                    'post_title' => 'Chapter One'
+                ];
+                allow('get_post_parent')->toBeCalled()->andReturn($parentPost);
+                allow('get_posts')->toBeCalled()->andReturn([
+                    $post = (object) [
+                        'ID' => 456,
+                        'post_title' => 'Chapter Two'
+                    ],
+                    (object) [
+                        'ID' => 789,
+                        'post_title' => 'Chapter Three'
+                    ]
+                ]);
+                expect('get_posts')->toBeCalled()->once()->with([
+                    'post_parent' => 123,
+                    'post_type' => 'long-read',
+                    'posts_per_page' => -1,
+                    'orderby' => 'menu_order',
+                    'order' => 'ASC'
+                ]);
+                allow('get_permalink')->toBeCalled()->andReturn('http://chapter-one-link', 'http://chapter-three-link');
+
+                $result = $this->chapterNavigation->getItems();
+
+                expect(count($result))->toEqual(3);
+                expect($result[0]->title)->toEqual('Chapter One');
+                expect($result[0]->url)->toEqual('http://chapter-one-link');
+                expect($result[1]->title)->toEqual('Chapter Two');
+                expect($result[1]->url)->toEqual(null);
+                expect($result[2]->title)->toEqual('Chapter Three');
+                expect($result[2]->url)->toEqual('http://chapter-three-link');
+            });
+        });
+    });
+});

--- a/spec/heading_anchors.spec.php
+++ b/spec/heading_anchors.spec.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LongReadPlugin;
+
+describe(HeadingAnchors::class, function () {
+    beforeEach(function () {
+        $this->headingAnchors = new HeadingAnchors();
+    });
+
+    it('is registrable', function () {
+        expect($this->headingAnchors)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+    });
+
+    describe('->register()', function () {
+        it('adds the filter', function () {
+            allow('add_filter')->toBeCalled();
+            expect('add_filter')->toBeCalled()->once();
+            expect('add_filter')->toBeCalled()->with('block_editor_settings_all', [$this->headingAnchors, 'enforceAnchors']);
+            $this->headingAnchors->register();
+        });
+    });
+
+    describe('->enforceAnchors', function () {
+        it('sets __experimentalGenerateAnchors to true', function () {
+            $settings = [];
+            $result = $this->headingAnchors->enforceAnchors($settings);
+            expect($result['__experimentalGenerateAnchors'])->toEqual(true);
+        });
+    });
+});

--- a/spec/in_page_navigation.spec.php
+++ b/spec/in_page_navigation.spec.php
@@ -1,0 +1,77 @@
+<?php
+
+describe(LongReadPlugin\InPageNavigation::class, function () {
+    beforeEach(function () {
+        $this->inPageNavigation = new \LongReadPlugin\InPageNavigation();
+    });
+
+    describe('->getItems()', function () {
+        it('does not return anything for non-heading blocks', function () {
+            global $post;
+            $post->post_content = 'Some content';
+            $blocks = [
+                [
+                    'blockName' => 'not-heading'
+                ],
+                [
+                    'blockName' => 'also-not-heading'
+                ],
+            ];
+            allow('parse_blocks')->toBeCalled()->andReturn($blocks);
+
+            $result = $this->inPageNavigation->getItems();
+
+            expect($result)->toEqual([]);
+        });
+
+        it('does not return anything for heading blocks not of level 2', function () {
+            global $post;
+            $post->post_content = 'Some content';
+            $blocks = [
+                [
+                    'blockName' => 'core/heading',
+                    'attrs' => [
+                        'level' => 3
+                    ]
+                ],
+                [
+                    'blockName' => 'core/heading',
+                    'attrs' => [
+                        'level' => 4
+                    ]
+                ],
+            ];
+            allow('parse_blocks')->toBeCalled()->andReturn($blocks);
+
+            $result = $this->inPageNavigation->getItems();
+
+            expect($result)->toEqual([]);
+        });
+
+        it('returns items for heading blocks with no level (as level 2 is the default)', function () {
+            global $post;
+            $post->post_content = 'Some content';
+            $blocks = [
+                [
+                    'blockName' => 'core/heading',
+                    'attrs' => [],
+                    'innerHTML' => '<h2 id="first-heading">First heading</h2>'
+                ],
+                [
+                    'blockName' => 'core/heading',
+                    'attrs' => [],
+                    'innerHTML' => '<h2 id="second-heading">Second heading</h2>'
+                ],
+            ];
+            allow('parse_blocks')->toBeCalled()->andReturn($blocks);
+
+            $result = $this->inPageNavigation->getItems();
+
+            expect(count($result))->toEqual(2);
+            expect($result[0]->title)->toEqual("First heading");
+            expect($result[0]->id)->toEqual('first-heading');
+            expect($result[1]->title)->toEqual("Second heading");
+            expect($result[1]->id)->toEqual('second-heading');
+        });
+    });
+});

--- a/src/ChapterNavigation.php
+++ b/src/ChapterNavigation.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace LongReadPlugin ;
+
+class ChapterNavigation
+{
+    public function getItems() : array
+    {
+        global $post;
+        $potentialParent = get_post_parent($post);
+        $parentPost = $potentialParent ? $potentialParent : $post;
+        $chapterPosts = get_posts([
+            'post_parent' => $parentPost->ID,
+            'post_type' => 'long-read',
+            'posts_per_page' => -1,
+            'orderby' => 'menu_order',
+            'order' => 'ASC'
+        ]);
+        array_unshift($chapterPosts, $parentPost);
+        $chapterNavigationItems = [];
+        foreach ($chapterPosts as $chapterPost) {
+            $chapterNavigationItems[] = (object) [
+                'title' => $chapterPost->post_title,
+                'url' => $chapterPost->ID == $post->ID ? null : get_permalink($chapterPost)
+            ];
+        }
+        return $chapterNavigationItems;
+    }
+}

--- a/src/HeadingAnchors.php
+++ b/src/HeadingAnchors.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace LongReadPlugin;
+
+class HeadingAnchors implements \Dxw\Iguana\Registerable
+{
+    public function register() : void
+    {
+        add_filter('block_editor_settings_all', [$this, 'enforceAnchors']);
+    }
+
+    public function enforceAnchors(array $settings) : array
+    {
+        $settings['__experimentalGenerateAnchors'] = true;
+        return $settings;
+    }
+}

--- a/src/InPageNavigation.php
+++ b/src/InPageNavigation.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LongReadPlugin;
+
+class InPageNavigation
+{
+    public function getItems() : array
+    {
+        $inPageNavItems = [];
+        global $post;
+        $blocks = parse_blocks($post->post_content);
+        foreach ($blocks as $block) {
+            if ($block['blockName'] == 'core/heading' && array_key_exists('attrs', $block) && (!isset($block['attrs']['level']) || $block['attrs']['level'] == 2)) {
+                $matches = [];
+                preg_match('/(id=")(.*)"/', $block['innerHTML'], $matches);
+                $inPageNavItems[] = (object) [
+                    'title' => trim(strip_tags($block["innerHTML"])),
+                    'id' => $matches[2]
+                ];
+            }
+        }
+        return $inPageNavItems;
+    }
+}

--- a/src/di.php
+++ b/src/di.php
@@ -1,3 +1,4 @@
 <?php
 
 $registrar->addInstance(new \LongReadPlugin\PostType());
+$registrar->addInstance(new \LongReadPlugin\HeadingAnchors());


### PR DESCRIPTION
This PR adds two classes (`ChapterNavigation` and `InPageNavigation`) which return return arrays of objects, which can be used to generate the navigation for long-read posts.

The intention is not that these methods will be directly called by themes using this plugin, as a later commit will introduce a static method that will integrate the results from these two classes into a single array, and it is that which will be called from within a theme. This PR is merely setting up the logic that will be utilised in that later work.

This PR also enforces the attachment of `id` attributes to any core/heading blocks when rendered in the front-end, to ensure that in-page navigation can be built based on that heading structure.