### PR TITLE
Provide static function for getting nav items in theme

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -12,6 +12,8 @@
     <UndefinedFunction errorLevel="suppress"/>
     <UndefinedConstant errorLevel="suppress"/>
     <UndefinedClass errorLevel="suppress"/>
+    <TypeDoesNotContainType errorLevel="suppress"/>
+    <RedundantPropertyInitializationCheck errorLevel="suppress"/>
     <!-- Suppress the complaint about $registrar just in this file -->
     <UndefinedGlobalVariable>
       <errorLevel type="suppress">

--- a/spec/navigation.spec.php
+++ b/spec/navigation.spec.php
@@ -1,0 +1,62 @@
+<?php
+
+use Kahlan\Plugin\Double;
+
+describe(LongReadPlugin\Navigation::class, function () {
+    beforeEach(function () {
+    });
+
+    describe('::getItems()', function () {
+        it('returns an empty array if an instance of the class does not already exist', function () {
+            $result = LongReadPlugin\Navigation::getItems();
+            expect($result)->toEqual([]);
+        });
+
+        it('returns an array of items where the in page nav is mapped to the subItems property of the current post item in the chapter nav items', function () {
+            $this->chapterNavigation = Double::instance(['extends' => '\LongReadPlugin\ChapterNavigation']);
+            $this->inPageNavigation = Double::instance(['extends' => '\LongReadPlugin\InPageNavigation']);
+            allow($this->chapterNavigation)->toReceive('getItems')->andReturn([
+                (object) [
+                    'title' => 'Chapter One',
+                    'url' => 'http://chapter-one'
+                ],
+                (object) [
+                    'title' => 'Current Chapter',
+                    'url' => null
+                ],
+                (object) [
+                    'title' => 'Chapter Three',
+                    'url' => 'http://chapter-three'
+                ]
+            ]);
+            allow($this->inPageNavigation)->toReceive('getItems')->andReturn([
+                (object) [
+                    'title' => 'Heading One',
+                    'id' => 'heading-one'
+                ],
+                (object) [
+                    'title' => 'Heading Two',
+                    'id' => 'heading-two'
+                ]
+            ]);
+            $navigation = new LongReadPlugin\Navigation(
+                $this->chapterNavigation,
+                $this->inPageNavigation
+            );
+
+            $result = LongReadPlugin\Navigation::getItems();
+            
+            expect(count($result))->toEqual(3);
+            expect($result[0]->title)->toEqual('Chapter One');
+            expect($result[0]->url)->toEqual('http://chapter-one');
+            expect($result[1]->title)->toEqual('Current Chapter');
+            expect(count($result[1]->subItems))->toEqual(2);
+            expect($result[1]->subItems[0]->title)->toEqual('Heading One');
+            expect($result[1]->subItems[0]->id)->toEqual('heading-one');
+            expect($result[1]->subItems[1]->title)->toEqual('Heading Two');
+            expect($result[1]->subItems[1]->id)->toEqual('heading-two');
+            expect($result[2]->title)->toEqual('Chapter Three');
+            expect($result[2]->url)->toEqual('http://chapter-three');
+        });
+    });
+});

--- a/src/Navigation.php
+++ b/src/Navigation.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LongReadPlugin;
+
+class Navigation
+{
+    private static ChapterNavigation $chapterNavigation;
+    private static InPageNavigation $inPageNavigation;
+
+    public function __construct(ChapterNavigation $chapterNavigation, InPageNavigation $inPageNavigation)
+    {
+        static::$chapterNavigation = $chapterNavigation;
+        static::$inPageNavigation = $inPageNavigation;
+    }
+
+    public static function getItems() : array
+    {
+        if (!isset(static::$chapterNavigation) || !isset(static::$inPageNavigation)) {
+            return [];
+        }
+        $chapterNavItems = static::$chapterNavigation->getItems();
+        $inPageNavItems = static::$inPageNavigation->getItems();
+        foreach ($chapterNavItems as $chapterNavItem) {
+            if ($chapterNavItem->url === null) {
+                $chapterNavItem->subItems = $inPageNavItems;
+            }
+        }
+        return $chapterNavItems;
+    }
+}

--- a/src/di.php
+++ b/src/di.php
@@ -2,3 +2,7 @@
 
 $registrar->addInstance(new \LongReadPlugin\PostType());
 $registrar->addInstance(new \LongReadPlugin\HeadingAnchors());
+$registrar->addInstance(new \LongReadPlugin\Navigation(
+    new LongReadPlugin\ChapterNavigation(),
+    new LongReadPlugin\InPageNavigation()
+));


### PR DESCRIPTION
This commit adds a new class, `LongReadPlugin\Navigation`, along with a
static method `::getItems()`, that can be called from within a theme to
return all the data required to build the in-page nav.

The method returns an array of objects, in the format:

```
[
  (object) [
    'title' => 'Title of first chapter',
    'url' => 'URL of first chapter'
  ],
  (object) [
    'title' => 'Title of current chapter',
    'url' => null //url is always null for currently viewed chapter
    'subItems' => [
      (object) [
        'title' => 'First in-page nav h2',
        'id' => 'id-of-first-in-page-h2'
      ],
      (object) [
        'title' => 'Second in-page nav h2',
        'id' => 'id-of-second-in-page-h2'
      ]
    ],
    (object) [
      'title' => 'Title of third chapter',
      'url' => 'URL of third chapter'
    ]
    ...
]
```

This should be sufficient to then build out in-page nav using any markup
we like within the theme. This seems preferable to trying to return the
markup directly from the plugin, which would be a bit clunky and
probably not give us a result that would work consistently across themes
anyway.

There a couple of extra things to note here:

1. I've chosen to return an empty array from the ::getItems() method if
it is somehow called without the class having already been constructed
(e.g. if there's a template that calls it, but the plugin is
deactivated). This should just result in the nav disappearing, which
seems preferable to a louder error (e.g. an exception being thrown).
2. I've had to suppress Psalm's `PropertyNotSetInConstructor` error,
because it can't deal with the possibility of properties that are set in
the constructor not being set when you check for them within a method.

The approach of having a static method that depends on an instance of the class
which it is attached to having already been newed-up does feel 
slightly counter-intuitive to me, and I'm a bit concerned it's an anti-pattern.
But the only alternative is to have a static method that calls other static
methods, which also feels smelly. Given the static method should only
be called when the plugin is active (and therefore we can be confident
that an instance of the class does exist), I think this is a reasonable
compromise, which keeps the code concise and testable.