### PR TITLE
Feature/default template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,79 @@
+# Long Read Plugin
+
+This plugin provides the basic functionality for adding "long read" items (i.e. multi-page documents divided into "chapters", with in-chapter and between-chapter navigation) to a WordPress site.
+
+A single "long read" is composed of a parent long read post, and it's direct children. The parent post will function as the first chapter of the long read, and its children as the subsequent chapters.
+
+## What this plugin does
+
+1. Adds the "long read" post type
+1. Enforces the block editor for that post type (even if the classic editor plugin is activated)
+1. Provides access to a static method that returns the data required to build the long read navigation. In-chapter navigation is based on the `h2`s used within a single long read post, between-chapter navigation is based on parrent/sibling relationships. The plugin enforces the auto-generation of IDs attached to heading blocks to help with this.
+1. Provides a basic long read template, compatible with the [dxw gov.uk theme](https://github.com/dxw/govuk-theme). This is mainly intended to be used as an example of how you might build your own long read template within your own custom theme.
+
+## How to use this plugin
+
+Recommended plugin to run alongside this:
+
+- [Nested Pages](https://en-gb.wordpress.org/plugins/wp-nested-pages/). Long read chapters are ordered according to the WordPress "menu order". This plugin allows you to set that via clicking & dragging in the admin post listing, rather than having to manually set the menu order on each individual long read post.
+
+1. Install this plugin (ideally via [Whippet](https://github.com/dxw/whippet)), and activate it
+1. Add a `single-long-read.php` template to your site's theme. This will display all long read content.
+1. Within that template, call `LongReadPlugin\Navigation::getItems()` to return the data required to build the navigation. See this repo's [example template](/template/single-long-read.php) for how to use the data returned. The method returns an array of objects, structured as follows:
+    ```php
+    [
+        (object) [
+            'title' => 'The parent long read post'
+            'url' => 'http://url-of-parent-long-read-post'
+        ],
+        (object) [
+            'title' => 'The first direct child of the parent long read post, by menu order'
+            'url' => 'http://url-of-first-direct-child'
+        ],
+        (object) [
+            'title' => 'The second direct child of the parent long read post, by menu order'
+            'url' => 'http://url-of-second-direct-child'
+        ],
+        (object) [
+            'title' => 'The third direct child, and currently viewed post',
+            'url' => null //The post currently being viewed will always have a null url
+            'subItems' => [
+                // An array of the h2s within the currently viewed post
+                (object) [
+                    'title' => 'First heading 2'
+                    'id' => 'id-of-first-h2',
+                ],
+                (object) [
+                    'title' => 'Second heading 2'
+                    'id' => 'id-of-second-h2',
+                ],
+                ...
+            ]
+        ],
+        (object) []
+            'title' => 'The fourth direct child of the parent long read post, by menu order'
+            'url' => 'http://url-of-fourth-direct-child'
+        ],
+        ...
+    ]
+    ```
+1. Style your long read template as required.
+
+## Development
+
+Install the dependencies:
+
+```
+composer install
+```
+
+Run the tests:
+```
+vendor/bin/kahlan spec
+```
+
+Run the linters:
+```
+vendor/bin/psalm
+vendor/bin/php-cs-fixer fix
+```

--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@
  * Description: Adds the underlying functionality to enable long-reads
  * Author: dxw
  * Version: 0.1.0
- * Network: True
+ * Network: false
  */
 
 $registrar = require __DIR__.'/src/load.php';

--- a/spec/options.spec.php
+++ b/spec/options.spec.php
@@ -12,8 +12,9 @@ describe(\LongReadPlugin\Options::class, function () {
     describe('->register()', function () {
         it('adds the action', function () {
             allow('add_action')->toBeCalled();
-            expect('add_action')->toBeCalled()->once();
+            expect('add_action')->toBeCalled()->times(2);
             expect('add_action')->toBeCalled()->once()->with('acf/init', [$this->options, 'addOptionsPage']);
+            expect('add_action')->toBeCalled()->once()->with('acf/init', [$this->options, 'addOptions']);
 
             $this->options->register();
         });
@@ -35,6 +36,26 @@ describe(\LongReadPlugin\Options::class, function () {
                 expect('acf_add_options_page')->toBeCalled()->once()->with(\Kahlan\Arg::toBeAn('array'));
 
                 $this->options->addOptionsPage();
+            });
+        });
+    });
+
+    describe('->addOptions()', function () {
+        context('ACF is not activated', function () {
+            it('does nothing', function () {
+                allow('function_exists')->toBeCalled()->andReturn(false);
+
+                $this->options->addOptionsPage();
+            });
+        });
+
+        context('ACF is activated', function () {
+            it('adds the options page', function () {
+                allow('function_exists')->toBeCalled()->andReturn(true);
+                allow('acf_add_local_field_group')->toBeCalled();
+                expect('acf_add_local_field_group')->toBeCalled()->once()->with(\Kahlan\Arg::toBeAn('array'));
+
+                $this->options->addOptions();
             });
         });
     });

--- a/spec/options.spec.php
+++ b/spec/options.spec.php
@@ -1,0 +1,41 @@
+<?php
+
+describe(\LongReadPlugin\Options::class, function () {
+    beforeEach(function () {
+        $this->options = new \LongReadPlugin\Options();
+    });
+
+    it('is registerable', function () {
+        expect($this->options)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+    });
+
+    describe('->register()', function () {
+        it('adds the action', function () {
+            allow('add_action')->toBeCalled();
+            expect('add_action')->toBeCalled()->once();
+            expect('add_action')->toBeCalled()->once()->with('acf/init', [$this->options, 'addOptionsPage']);
+
+            $this->options->register();
+        });
+    });
+
+    describe('->addOptionsPage()', function () {
+        context('ACF is not activated', function () {
+            it('does nothing', function () {
+                allow('function_exists')->toBeCalled()->andReturn(false);
+
+                $this->options->addOptionsPage();
+            });
+        });
+
+        context('ACF is activated', function () {
+            it('adds the options page', function () {
+                allow('function_exists')->toBeCalled()->andReturn(true);
+                allow('acf_add_options_page')->toBeCalled();
+                expect('acf_add_options_page')->toBeCalled()->once()->with(\Kahlan\Arg::toBeAn('array'));
+
+                $this->options->addOptionsPage();
+            });
+        });
+    });
+});

--- a/spec/template.spec.php
+++ b/spec/template.spec.php
@@ -1,0 +1,101 @@
+<?php
+
+describe(\LongReadPlugin\Template::class, function () {
+    beforeEach(function () {
+        $this->template = new \LongReadPlugin\Template();
+    });
+
+    it('is registerable', function () {
+        expect($this->template)->toBeAnInstanceOf(\Dxw\Iguana\Registerable::class);
+    });
+
+    describe('->register()', function () {
+        it('adds the filter', function () {
+            allow('add_filter')->toBeCalled();
+            expect('add_filter')->toBeCalled()->once();
+            expect('add_filter')->toBeCalled()->once()->with('single_template', [$this->template, 'useDefault'], 99);
+    
+            $this->template->register();
+        });
+    });
+
+    describe('->useDefault()', function () {
+        context('the post type is not long-read', function () {
+            it('returns the input', function () {
+                global $post;
+                $post = (object) [
+                    'post_type' => 'post'
+                ];
+
+                $result = $this->template->useDefault('standard-post-template');
+
+                expect($result)->toEqual('standard-post-template');
+            });
+        });
+
+        context('ACF is not activated', function () {
+            it('returns the input', function () {
+                global $post;
+                $post = (object) [
+                    'post_type' => 'long-read'
+                ];
+                allow('function_exists')->toBeCalled()->andReturn(false);
+
+                $result = $this->template->useDefault('standard-post-template');
+
+                expect($result)->toEqual('standard-post-template');
+            });
+        });
+
+        context('the option to use the plugin default template is not checked', function () {
+            it('returns the input', function () {
+                global $post;
+                $post = (object) [
+                    'post_type' => 'long-read'
+                ];
+                allow('function_exists')->toBeCalled()->andReturn(true);
+                allow('get_field')->toBeCalled()->andReturn(false);
+
+                $result = $this->template->useDefault('standard-post-template');
+
+                expect($result)->toEqual('standard-post-template');
+            });
+        });
+
+        context('the option to use the plugin default template is checked', function () {
+            context('but the template file does not exist', function () {
+                it('returns the input', function () {
+                    global $post;
+                    $post = (object) [
+                        'post_type' => 'long-read'
+                    ];
+                    allow('function_exists')->toBeCalled()->andReturn(true);
+                    allow('get_field')->toBeCalled()->andReturn(1);
+                    allow('file_exists')->toBeCalled()->andReturn(false);
+                    allow('plugin_dir_path')->toBeCalled()->andReturn('the/plugin/path');
+                    allow('dirname')->toBeCalled()->andReturn('the/plugin');
+    
+                    $result = $this->template->useDefault('standard-post-template');
+    
+                    expect($result)->toEqual('standard-post-template');
+                });
+            });
+
+            it('returns the path to the plugin template', function () {
+                global $post;
+                $post = (object) [
+                    'post_type' => 'long-read'
+                ];
+                allow('function_exists')->toBeCalled()->andReturn(true);
+                allow('get_field')->toBeCalled()->andReturn(1);
+                allow('file_exists')->toBeCalled()->andReturn(true);
+                allow('plugin_dir_path')->toBeCalled()->andReturn('the/plugin/path');
+                allow('dirname')->toBeCalled()->andReturn('the/plugin');
+
+                $result = $this->template->useDefault('standard-post-template');
+
+                expect($result)->toEqual('the/plugin/template/' . \LongReadPlugin\Template::TEMPLATE_FILE);
+            });
+        });
+    });
+});

--- a/src/Options.php
+++ b/src/Options.php
@@ -7,6 +7,7 @@ class Options implements \Dxw\Iguana\Registerable
     public function register() : void
     {
         add_action('acf/init', [$this, 'addOptionsPage']);
+        add_action('acf/init', [$this, 'addOptions']);
     }
 
     public function addOptionsPage() : void
@@ -20,5 +21,56 @@ class Options implements \Dxw\Iguana\Registerable
                 'parent_slug' => 'options-general.php'
             ]);
         }
+    }
+
+    public function addOptions() : void
+    {
+        if (function_exists('acf_add_local_field_group')):
+
+            acf_add_local_field_group([
+                'key' => 'group_long_read_plugin_settings',
+                'title' => 'Long Read Settings',
+                'fields' => [
+                    [
+                        'key' => 'field_long_read_plugin_settings-default_template',
+                        'label' => 'Use default template',
+                        'name' => 'long_read_plugin_use_default_template',
+                        'type' => 'true_false',
+                        'instructions' => 'Use the default template for Long Read posts? (Requires a theme based on the dxw gov.uk theme)',
+                        'required' => 0,
+                        'conditional_logic' => 0,
+                        'wrapper' => [
+                            'width' => '',
+                            'class' => '',
+                            'id' => '',
+                        ],
+                        'message' => '',
+                        'default_value' => 0,
+                        'ui' => 0,
+                        'ui_on_text' => '',
+                        'ui_off_text' => '',
+                    ],
+                ],
+                'location' => [
+                    [
+                        [
+                            'param' => 'options_page',
+                            'operator' => '==',
+                            'value' => 'long-read-settings',
+                        ],
+                    ],
+                ],
+                'menu_order' => 0,
+                'position' => 'normal',
+                'style' => 'default',
+                'label_placement' => 'top',
+                'instruction_placement' => 'label',
+                'hide_on_screen' => '',
+                'active' => true,
+                'description' => '',
+                'show_in_rest' => 0,
+            ]);
+            
+        endif;
     }
 }

--- a/src/Options.php
+++ b/src/Options.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LongReadPlugin;
+
+class Options implements \Dxw\Iguana\Registerable
+{
+    public function register() : void
+    {
+        add_action('acf/init', [$this, 'addOptionsPage']);
+    }
+
+    public function addOptionsPage() : void
+    {
+        if (function_exists('acf_add_options_page')) {
+            acf_add_options_page([
+                'page_title' 	=> 'Long Read Settings',
+                'menu_title'	=> 'Long Read Settings',
+                'menu_slug' 	=> 'long-read-settings',
+                'capability'	=> 'edit_posts',
+                'parent_slug' => 'options-general.php'
+            ]);
+        }
+    }
+}

--- a/src/Template.php
+++ b/src/Template.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace LongReadPlugin;
+
+class Template implements \Dxw\Iguana\Registerable
+{
+    const TEMPLATE_FILE = 'single-long-read.php';
+
+    public function register() : void
+    {
+        add_filter('single_template', [$this, 'useDefault'], 99);
+    }
+
+    public function useDefault(string $template) : string
+    {
+        global $post;
+        if ($post->post_type == 'long-read' && function_exists('get_field') && get_field('long_read_plugin_use_default_template', 'option')) {
+            if (file_exists(dirname(plugin_dir_path(__FILE__)) . '/template/' . self::TEMPLATE_FILE)) {
+                $template = dirname(plugin_dir_path(__FILE__)) . '/template/' . self::TEMPLATE_FILE;
+            }
+        }
+    
+        return $template;
+    }
+}

--- a/src/di.php
+++ b/src/di.php
@@ -7,3 +7,4 @@ $registrar->addInstance(new \LongReadPlugin\Navigation(
     new LongReadPlugin\InPageNavigation()
 ));
 $registrar->addInstance(new \LongReadPlugin\Options());
+$registrar->addInstance(new \LongReadPlugin\Template());

--- a/src/di.php
+++ b/src/di.php
@@ -6,3 +6,4 @@ $registrar->addInstance(new \LongReadPlugin\Navigation(
     new LongReadPlugin\ChapterNavigation(),
     new LongReadPlugin\InPageNavigation()
 ));
+$registrar->addInstance(new \LongReadPlugin\Options());

--- a/template/single-long-read.php
+++ b/template/single-long-read.php
@@ -1,0 +1,37 @@
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <article>
+            <header>
+                <h1><?php the_title(); ?></h1>
+            </header>
+
+            <div class="entry content rich-text">
+                <?php the_content(); ?>
+            </div>
+
+        </article>
+    </div>
+    <div class="govuk-grid-column-one-third">
+        <div class="long-read-navigation__container">
+            <nav class="long-read-navigation">
+                <h2>Chapter navigation</h2>
+                <?php $items = LongReadPlugin\Navigation::getItems();
+                    echo "<ul class='long-read-navigation__items'>";
+                    foreach ($items as $item) {
+                        if ($item->url) {
+                            printf("<li class='long-read-navigation__item'><a href='%s'>%s</a></li>", esc_url($item->url), wp_kses_post($item->title));
+                        } else {
+                            printf("<li class='long-read-navigation__item long-read-navigation__current-item'>%s</li>", wp_kses_post($item->title));
+                            echo "<ul>";
+                            foreach ($item->subItems as $subItem) {
+                                printf("<li class='long-read-navigation__in-page-item'><a href='#%s'>%s</a></li>", esc_attr($subItem->id), wp_kses_post($subItem->title));
+                            }
+                            echo "</ul>";
+                        }
+                    }
+                    echo "</ul>";
+                ?>
+            </nav>
+        </div>
+    </div>
+</div> 


### PR DESCRIPTION
This PR:

- Adds an example long read template
- Adds an option page where this in-built template can be used as the long read template within a theme. This will only work in a theme based on the dxw govuk theme, so this is mainly intended as an option we might use to provide a quick demo, with a custom template being developed for long-term use
- Adds a README explaining how to use the plugin
- Allows the plugin to be activated on individual subsites in a network, rather than only at the network level