### PR TITLE
Fix/allow for null type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2022-05-19
+### Amended
+- Allow for possible null in call to `use_block_editor_for_post_type` filter
+
 ## [1.0.0] - 2022-05-19
 - Initial release

--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/dxw/long-read-plugin
  * Description: Adds the underlying functionality to enable long-reads
  * Author: dxw
- * Version: 1.0.0
+ * Version: 1.0.1
  * Network: false
  */
 

--- a/src/PostType.php
+++ b/src/PostType.php
@@ -37,7 +37,11 @@ class PostType implements \Dxw\Iguana\Registerable
         ]);
     }
 
-    public function enforceBlockEditor(bool $useBlockEditor, string $postType) : bool
+    /**
+    * @param bool|null $useBlockEditor
+    * @return bool|null
+    */
+    public function enforceBlockEditor($useBlockEditor, string $postType)
     {
         if ($postType === 'long-read') {
             return true;


### PR DESCRIPTION
This PR:

- Allows for the possibility of the first parameter being passed to the `use_block_editor_for_post_type` filter being null, rather than a boolean (despite the claims of the docs 😬 https://developer.wordpress.org/reference/hooks/use_block_editor_for_post_type/)
- Bumps the version to 1.0.1 to release this fix