### PR TITLE
Feature/override classic editor preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2022-05-26
+### Amended
+- Ensure block editor is enforced, even if an individual user has chosen "classic" as their preferred editor in the classic editor plugin
+
 ## [1.0.1] - 2022-05-19
 ### Amended
 - Allow for possible null in call to `use_block_editor_for_post_type` filter

--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/dxw/long-read-plugin
  * Description: Adds the underlying functionality to enable long-reads
  * Author: dxw
- * Version: 1.0.1
+ * Version: 1.0.2
  * Network: false
  */
 

--- a/spec/post_type.spec.php
+++ b/spec/post_type.spec.php
@@ -17,8 +17,9 @@ describe(\LongReadPlugin\PostType::class, function () {
             expect('add_action')->toBeCalled()->once();
             expect('add_action')->toBeCalled()->once()->with('init', [$this->postType, 'registerPostType']);
             allow('add_filter')->toBeCalled();
-            expect('add_filter')->toBeCalled()->once();
+            expect('add_filter')->toBeCalled()->times(2);
             expect('add_filter')->toBeCalled()->once()->with('use_block_editor_for_post_type', [$this->postType, 'enforceBlockEditor'], 1000, 2);
+            expect('add_filter')->toBeCalled()->once()->with('get_user_option_classic-editor-settings', [$this->postType, 'overrideUserEditorSelection'], 10, 1);
             $this->postType->register();
         });
     });
@@ -44,6 +45,45 @@ describe(\LongReadPlugin\PostType::class, function () {
                 $result = $this->postType->enforceBlockEditor(false, 'long-read');
                 expect($result)->toBeA('boolean');
                 expect($result)->toEqual(true);
+            });
+        });
+    });
+
+    describe('->overrideUserEditorSelection()', function () {
+        context('the post_type parameter is not set', function () {
+            it('returns the input', function () {
+                global $_GET;
+                $_GET = [];
+
+                $result = $this->postType->overrideUserEditorSelection('foo');
+
+                expect($result)->toEqual('foo');
+            });
+        });
+
+        context('the post_type parameter is set to something other than long-read', function () {
+            it('returns the input', function () {
+                global $_GET;
+                $_GET = [
+                    'post_type' => 'post'
+                ];
+
+                $result = $this->postType->overrideUserEditorSelection('foo');
+
+                expect($result)->toEqual('foo');
+            });
+        });
+
+        context('the post_type parameter is set to long-read', function () {
+            it('returns "block"', function () {
+                global $_GET;
+                $_GET = [
+                    'post_type' => 'long-read'
+                ];
+
+                $result = $this->postType->overrideUserEditorSelection('foo');
+
+                expect($result)->toEqual('block');
             });
         });
     });

--- a/src/PostType.php
+++ b/src/PostType.php
@@ -10,6 +10,10 @@ class PostType implements \Dxw\Iguana\Registerable
         // The value for this filter we want to override is applied with priority 100
         // So we use priority 1000 to override
         add_filter('use_block_editor_for_post_type', [$this, 'enforceBlockEditor'], 1000, 2);
+        // The above override works if the classic editor is active site-wide
+        // But not if it allows users to pick a preference of block or classic
+        // So we need another filter to override individual user preferences
+        add_filter('get_user_option_classic-editor-settings', [$this, 'overrideUserEditorSelection'], 10, 1);
     }
 
     public function registerPostType() : void
@@ -47,5 +51,17 @@ class PostType implements \Dxw\Iguana\Registerable
             return true;
         }
         return $useBlockEditor;
+    }
+
+    /**
+    * @param mixed $result
+    * @return mixed
+    */
+    public function overrideUserEditorSelection($result)
+    {
+        if (isset($_GET['post_type']) && $_GET['post_type'] == 'long-read') {
+            return 'block';
+        }
+        return $result;
     }
 }


### PR DESCRIPTION
This PR fixes a bug where, if the classic editor plugin is active and set to allow individual users to pick their preferred editor, a user who selected the classic editor as their preference would be presented with the classic editor when editing a long-read post. They will know be shown the block editor for long-read editing, regardless of their selected preference.