### PR TITLE
Fix/enforce heading anchors in wordpress 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3] - 2022-05-27
+### Amended
+- Ensure heading anchors are generated in WordPress v6.0
+
 ## [1.0.2] - 2022-05-26
 ### Amended
 - Ensure block editor is enforced, even if an individual user has chosen "classic" as their preferred editor in the classic editor plugin

--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/dxw/long-read-plugin
  * Description: Adds the underlying functionality to enable long-reads
  * Author: dxw
- * Version: 1.0.2
+ * Version: 1.0.3
  * Network: false
  */
 

--- a/spec/heading_anchors.spec.php
+++ b/spec/heading_anchors.spec.php
@@ -25,6 +25,7 @@ describe(HeadingAnchors::class, function () {
             $settings = [];
             $result = $this->headingAnchors->enforceAnchors($settings);
             expect($result['__experimentalGenerateAnchors'])->toEqual(true);
+            expect($result['generateAnchors'])->toEqual(true);
         });
     });
 });

--- a/src/HeadingAnchors.php
+++ b/src/HeadingAnchors.php
@@ -11,7 +11,10 @@ class HeadingAnchors implements \Dxw\Iguana\Registerable
 
     public function enforceAnchors(array $settings) : array
     {
+        /* In WordPress pre-v6, this was an experimental setting */
         $settings['__experimentalGenerateAnchors'] = true;
+        /* From v6 onwards, it's a standard setting */
+        $settings['generateAnchors'] = true;
         return $settings;
     }
 }


### PR DESCRIPTION
The `__experimentalGenerateAnchors` setting is now longer experimental
in WordPress v6, and has no effect. - it's just `generateAnchors` now.

So let's set both to ensure compatibility pre and post v6.