### PR TITLE
Feature/parent item title in heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0] - 2022-08-15
+### Added
+- `\LongReadPlugin\ParentTitle::get()` to return title of top-level long-read item
 
 ## [1.0.3] - 2022-05-27
 ### Amended

--- a/index.php
+++ b/index.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/dxw/long-read-plugin
  * Description: Adds the underlying functionality to enable long-reads
  * Author: dxw
- * Version: 1.0.3
+ * Version: 1.1.0
  * Network: false
  */
 

--- a/spec/parent_title.spec.php
+++ b/spec/parent_title.spec.php
@@ -1,0 +1,39 @@
+<?php
+
+describe(\LongReadPlugin\ParentTitle::class, function () {
+    describe('::get', function () {
+        context('there is no post parent', function () {
+            it('returns null', function () {
+                global $post;
+                $post = new stdClass();
+                allow('get_post_ancestors')->toBeCalled()->andReturn([]);
+                $result = \LongReadPlugin\ParentTitle::get();
+                expect($result)->toEqual(null);
+            });
+        });
+
+        context('there is only one post ancestors', function () {
+            it('returns the title of that parent', function () {
+                global $post;
+                $post = new stdClass();
+                allow('get_post_ancestors')->toBeCalled()->andReturn([123]);
+                allow('get_the_title')->toBeCalled()->andReturn('The parent title');
+                expect('get_the_title')->toBeCalled()->once()->with(123);
+                $result = \LongReadPlugin\ParentTitle::get();
+                expect($result)->toEqual('The parent title');
+            });
+        });
+
+        context('there is only multiple post ancestors', function () {
+            it('returns the title of the top level post ancestor', function () {
+                global $post;
+                $post = new stdClass();
+                allow('get_post_ancestors')->toBeCalled()->andReturn([123, 456, 789]);
+                allow('get_the_title')->toBeCalled()->andReturn('The top ancestor title');
+                expect('get_the_title')->toBeCalled()->once()->with(789);
+                $result = \LongReadPlugin\ParentTitle::get();
+                expect($result)->toEqual('The top ancestor title');
+            });
+        });
+    });
+});

--- a/src/ParentTitle.php
+++ b/src/ParentTitle.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace LongReadPlugin;
+
+class ParentTitle
+{
+    /**
+    * @return string|null
+    */
+    public static function get()
+    {
+        global $post;
+        $ancestors = get_post_ancestors($post);
+        $topLevelAncestor = array_pop($ancestors);
+        if ($topLevelAncestor) {
+            return get_the_title($topLevelAncestor);
+        }
+    }
+}

--- a/template/single-long-read.php
+++ b/template/single-long-read.php
@@ -2,6 +2,9 @@
     <div class="govuk-grid-column-two-thirds">
         <article>
             <header>
+                <?php if (LongReadPlugin\ParentTitle::get()) : ?>
+                    <span class="govuk-caption-l"><?php echo LongReadPlugin\ParentTitle::get(); ?></span>
+                <?php endif; ?>
                 <h1><?php the_title(); ?></h1>
             </header>
 


### PR DESCRIPTION
This PR adds a small new method, `LongReadPlugin\ParentTitle::get()` which returns the title of the top-level long-read post in a hierarchy. Long-read hierarchies should generally only go one item deep (as the default navigation construction doesn't go any deeper), but the method will return the title of the top-level ancestor if the hierarchy goes deeper.

The intention is that theme authors will use this method to display the overall long-read title in their long-read headings, as required. No markup is specified, so that theme developers can style and mark up the title however they wish. The default template has been updated to include the parent title, as an example of how this could be used.

The PR also bumps the plugin version to `1.1.0`.

Example of this using the govuk-theme, and the default long-read template:

<img width="621" alt="Screenshot 2022-08-15 at 16 54 28" src="https://user-images.githubusercontent.com/370665/184669936-40a1d3ba-e5bc-4bf6-85c7-100f6683fd9b.png">
