### PR TITLE
Change in page nav regex to a non-greedy match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleaseed]
+### Amended
+- Changed regex generating in-page anchors to use a non-greedy regex to eliminate issues with pasted in styling
+
 ## [1.1.0] - 2022-08-15
 ### Added
 - `\LongReadPlugin\ParentTitle::get()` to return title of top-level long-read item

--- a/src/InPageNavigation.php
+++ b/src/InPageNavigation.php
@@ -12,7 +12,7 @@ class InPageNavigation
         foreach ($blocks as $block) {
             if ($block['blockName'] == 'core/heading' && array_key_exists('attrs', $block) && (!isset($block['attrs']['level']) || $block['attrs']['level'] == 2)) {
                 $matches = [];
-                preg_match('/(id=")(.*)"/', $block['innerHTML'], $matches);
+                preg_match('/(id=")(.*?)"/', $block['innerHTML'], $matches);
                 $inPageNavItems[] = (object) [
                     'title' => trim(strip_tags($block["innerHTML"])),
                     'id' => $matches[2]


### PR DESCRIPTION
This commit changes the regex used to get the id used to generate the in page navigation links to use a non-greedy match, rather than a greedy one.

This was motivated by an issue noticed in the NHS England site, where on pasting in content from a word document the heading anchors were not reliably operating due to included content. This was determined to be caused by additional html markup included in the html, which has classes attached, the greedy match was matching up to the end of the classes in the additional html, using a non-greedy match resolves this issue safely, by stopping the regex at the first " encountered, rather than the last.

I have tested this against content with the included formating as per the article which exhibited the issues, and I have also tested that this works as expected should the heading being linked to includes "s in the text of the heading