### PR TITLE
Add headings from within block groups to in-page navigation

### DIFF
--- a/spec/in_page_navigation.spec.php
+++ b/spec/in_page_navigation.spec.php
@@ -73,5 +73,30 @@ describe(LongReadPlugin\InPageNavigation::class, function () {
             expect($result[1]->title)->toEqual("Second heading");
             expect($result[1]->id)->toEqual('second-heading');
         });
+
+        it('returns items for heading blocks within block-groups)', function () {
+            global $post;
+            $post->post_content = 'Some content';
+            $blocks = [
+                [
+                    'blockName' => 'core/group',
+                    'attrs' => [],
+                    'innerBlocks' => [
+                        [
+                            'blockName' => 'core/heading',
+                            'attrs' => [],
+                            'innerHTML' => '<h2 id="first-heading">First heading</h2>'
+                        ],
+                    ]
+                ]
+            ];
+            allow('parse_blocks')->toBeCalled()->andReturn($blocks);
+
+            $result = $this->inPageNavigation->getItems();
+
+            expect(count($result))->toEqual(1);
+            expect($result[0]->title)->toEqual("First heading");
+            expect($result[0]->id)->toEqual('first-heading');
+        });
     });
 });

--- a/src/InPageNavigation.php
+++ b/src/InPageNavigation.php
@@ -4,21 +4,36 @@ namespace LongReadPlugin;
 
 class InPageNavigation
 {
-    public function getItems() : array
+
+    /** @var array $inPageNavItems */
+    private $inPageNavItems = [];
+
+    private function parseHeading(string $html): \stdClass
     {
-        $inPageNavItems = [];
-        global $post;
-        $blocks = parse_blocks($post->post_content);
+        $matches = [];
+        preg_match('/(id=")(.*?)"/', $html, $matches);
+        return (object) [
+            'title' => trim(strip_tags($html)),
+            'id' => $matches[2]
+        ];
+    }
+
+    private function findHeadingBlocks(array $blocks): void
+    {
         foreach ($blocks as $block) {
-            if ($block['blockName'] == 'core/heading' && array_key_exists('attrs', $block) && (!isset($block['attrs']['level']) || $block['attrs']['level'] == 2)) {
-                $matches = [];
-                preg_match('/(id=")(.*?)"/', $block['innerHTML'], $matches);
-                $inPageNavItems[] = (object) [
-                    'title' => trim(strip_tags($block["innerHTML"])),
-                    'id' => $matches[2]
-                ];
+            if ($block['blockName'] == 'core/heading'  && array_key_exists('attrs', $block) && (!isset($block['attrs']['level']) || $block['attrs']['level'] == 2)) {
+                $this->inPageNavItems[] = $this->parseHeading($block["innerHTML"]);
+            } elseif ($block['blockName'] == 'acf/group-block' || $block['blockName'] == 'core/group') {
+                $this->findHeadingBlocks($block['innerBlocks']);
             }
         }
-        return $inPageNavItems;
+    }
+
+    public function getItems() : array
+    {
+        global $post;
+        $blocks = parse_blocks($post->post_content);
+        $this->findHeadingBlocks($blocks);
+        return $this->inPageNavItems;
     }
 }


### PR DESCRIPTION
- Previously, only headings in the root of the page were found
- This update recurses into block groups to find headings there

- Specifically, this is wanted for lambethtogether.net -- E.g. https://lambethtogether.net/long-read/nwda-report/thriving-communities/ should have the 'Context and key challenges' in the in-page navigation

- To test, copy the above long-read or create a long read and group blocks with a heading included

- Resolves: https://dxw.zendesk.com/agent/tickets/17292 / https://dxw.zendesk.com/agent/tickets/17261

Due to the nature of the dependencies for the changes, it is included in one commit. Technically this implements:
- Creates a recursive findHeadingBlocks() function to walk through the blocks looking for headings
- This needs a class-level storage of the found headings in inPageNavItems array
- Moves the parsing of the heading object for the nav into a callable parseHeading() function
- Refactors main getItems() method to use the above
