### PR TITLE
Release v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased (v2)
+## [v2.0.0] - 2025-03-25
 
 ### Changed
 

--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@
  * Plugin URI: https://github.com/dxw/long-read-plugin
  * Description: Adds the underlying functionality to enable long-reads
  * Author: dxw
- * Version: 1.1.3
+ * Version: 2.0.0
  * Network: false
  */
 


### PR DESCRIPTION
## Description

This release is a major version bump to v2.0.0. It signals the introduction of PHP 8 as a dependency and deprecation of PHP 7.4. 

Once the associated `v2` tag has been added, dependent project repos that support PHP 8 will need their versions bumped in `whippet.json`.
...

## Checklist
- [x] Changelog updated
- [x] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
