### PR TITLE
Fix/guard against missing matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- TOC generator skips empty heading blocks
+
 ## [v2.0.0] - 2025-03-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v2.0.1] - 2025-07-22
 
 ### Changed
 - TOC generator skips empty heading blocks

--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@
  * Plugin URI: https://github.com/dxw/long-read-plugin
  * Description: Adds the underlying functionality to enable long-reads
  * Author: dxw
- * Version: 2.0.0
+ * Version: 2.0.1
  * Network: false
  */
 

--- a/spec/in_page_navigation.spec.php
+++ b/spec/in_page_navigation.spec.php
@@ -24,6 +24,26 @@ describe(LongReadPlugin\InPageNavigation::class, function () {
 			expect($result)->toEqual([]);
 		});
 
+		it('does not return anything for heading blocks with no content', function () {
+			global $post;
+			$post->post_content = 'Some content';
+			$blocks = [
+				[
+					'blockName' => 'core/heading',
+					'attrs' => [
+						'level' => 2
+					],
+					'innerHTML' => '<h2 class="wp-block-heading"></h2>',
+					'innerContent' => ['<h2 class="wp-block-heading"></h2>']
+				],
+			];
+			allow('parse_blocks')->toBeCalled()->andReturn($blocks);
+
+			$result = $this->inPageNavigation->getItems();
+
+			expect($result)->toEqual([]);
+		});
+
 		it('does not return anything for heading blocks not of level 2', function () {
 			global $post;
 			$post->post_content = 'Some content';

--- a/src/InPageNavigation.php
+++ b/src/InPageNavigation.php
@@ -21,6 +21,9 @@ class InPageNavigation
 	{
 		foreach ($blocks as $block) {
 			if ($block['blockName'] == 'core/heading'  && array_key_exists('attrs', $block) && (!isset($block['attrs']['level']) || $block['attrs']['level'] == 2)) {
+				if (empty(trim(strip_tags($block['innerHTML'])))) {
+					continue;
+				}
 				$this->inPageNavItems[] = $this->parseHeading($block["innerHTML"]);
 			} elseif ($block['blockName'] == 'acf/group-block' || $block['blockName'] == 'core/group') {
 				$this->findHeadingBlocks($block['innerBlocks']);


### PR DESCRIPTION
## Description of changes

- guard against missing matches, fix for log error found on NHSE
- release v2.0.1

## Testing - UPDATED

On `main` branch:

1. Spin up a local site with this plugin installed, or clone the repo into a site you already have
2. Visit http://localhost/wp-admin/plugins.php and ensure the plugin is activated
3. Visit http://localhost/wp-admin/plugins.php and either add and activate or just activate query-monitor
4. Visit http://localhost/wp-admin/edit.php?post_type=long-read and add or edit a long read to add an `h2` heading block with NO text content in the block
5. Visit the long read page in the front end, and check you see an error `Undefined array key 2`
6. Change to this branch `git checkout fix/guard-against-missing-matches`
7. Refresh the page on the front end and confirm the error has dissappeared

## Checklist
- [x] Changelog updated
- [x] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
