### PR TITLE
Feature/toggle long read post type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v2.1.0] - 2026-04-01
+
+### Added
+
+- Option to deactivate long-read post type
 
 ### Changed
 
 - Composer dependencies updated
 - Scripts to rule them all pattern implemented
+
 
 ## [v2.0.1] - 2025-07-22
 

--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@
  * Plugin URI: https://github.com/dxw/long-read-plugin
  * Description: Adds the underlying functionality to enable long-reads
  * Author: dxw
- * Version: 2.0.1
+ * Version: 2.1.0
  * Network: false
  */
 

--- a/spec/post_type.spec.php
+++ b/spec/post_type.spec.php
@@ -27,7 +27,14 @@ describe(\LongReadPlugin\PostType::class, function () {
 	describe('->registerPostType()', function () {
 		it('registers the post type', function () {
 			allow('register_post_type')->toBeCalled();
+			allow('get_field')->toBeCalled()->andReturn(false);
 			expect('register_post_type')->toBeCalled()->once()->with(Arg::toBeA('string'), Arg::toBeAn('array'));
+			$this->postType->registerPostType();
+		});
+		it('does not register the post type if the option is set to deactivate it', function () {
+			allow('register_post_type')->toBeCalled();
+			allow('get_field')->toBeCalled()->andReturn(true);
+			expect('register_post_type')->not->toBeCalled();
 			$this->postType->registerPostType();
 		});
 	});

--- a/src/Options.php
+++ b/src/Options.php
@@ -50,6 +50,16 @@ class Options implements \Dxw\Iguana\Registerable
 						'ui_on_text' => '',
 						'ui_off_text' => '',
 					],
+					[
+						'key' => 'field_long_read_plugin_toggle_post_type',
+						'label' => 'Toggle custom post type',
+						'name' => 'long_read_plugin_toggle_post_type',
+						'type' => 'true_false',
+						'instructions' => 'Deactivate the custom post type for long read posts?',
+						'message' => '',
+						'default_value' => 0,
+						'ui' => 0,
+					],
 				],
 				'location' => [
 					[

--- a/src/PostType.php
+++ b/src/PostType.php
@@ -18,9 +18,9 @@ class PostType implements \Dxw\Iguana\Registerable
 
 	public function registerPostType(): void
 	{
-	/** @var bool $activatePostType */
-	$activatePostType = get_field('long_read_plugin_toggle_post_type', 'option');
-		
+		/** @var bool $activatePostType */
+		$activatePostType = get_field('long_read_plugin_toggle_post_type', 'option');
+
 		if (!$activatePostType) {
 			register_post_type('long-read', [
 				'label' => 'Long Reads',

--- a/src/PostType.php
+++ b/src/PostType.php
@@ -18,27 +18,32 @@ class PostType implements \Dxw\Iguana\Registerable
 
 	public function registerPostType(): void
 	{
-		register_post_type('long-read', [
-			'label' => 'Long Reads',
-			'labels' => [
-				'singular_name' => 'Long Read',
-				'add_new_item' => 'Add New Long Read',
-				'edit_item' => 'Edit Long Read',
-				'new_item' => 'New Long Read',
-				'view_item' => 'View Long Read',
-				'view_items' => 'View Long Reads'
-			],
-			'public' => true,
-			'hierarchical' => true,
-			'show_in_rest' => true,
-			'menu_icon' => 'dashicons-feedback',
-			'supports' => [
-				'revisions',
-				'page-attributes',
-				'editor',
-				'title'
-			]
-		]);
+	/** @var bool $activatePostType */
+	$activatePostType = get_field('long_read_plugin_toggle_post_type', 'option');
+		
+		if (!$activatePostType) {
+			register_post_type('long-read', [
+				'label' => 'Long Reads',
+				'labels' => [
+					'singular_name' => 'Long Read',
+					'add_new_item' => 'Add New Long Read',
+					'edit_item' => 'Edit Long Read',
+					'new_item' => 'New Long Read',
+					'view_item' => 'View Long Read',
+					'view_items' => 'View Long Reads'
+				],
+				'public' => true,
+				'hierarchical' => true,
+				'show_in_rest' => true,
+				'menu_icon' => 'dashicons-feedback',
+				'supports' => [
+					'revisions',
+					'page-attributes',
+					'editor',
+					'title'
+				]
+			]);
+		}
 	}
 
 	/**

--- a/src/PostType.php
+++ b/src/PostType.php
@@ -19,9 +19,9 @@ class PostType implements \Dxw\Iguana\Registerable
 	public function registerPostType(): void
 	{
 		/** @var bool $activatePostType */
-		$activatePostType = get_field('long_read_plugin_toggle_post_type', 'option');
+		$deactivatePostType = get_field('long_read_plugin_toggle_post_type', 'option');
 
-		if (!$activatePostType) {
+		if (!$deactivatePostType) {
 			register_post_type('long-read', [
 				'label' => 'Long Reads',
 				'labels' => [


### PR DESCRIPTION
## Description of changes

This feature adds an ACF option to allow administrators to deactivate the custom long-read post type. It will remain active by default, so existing implementations should remain unaffected.

To test, install the plugin on a site. Check that the long read post type is available by default. Go to > long read settings and deactivate the post type. Check that it no longer displays

## Checklist
- [x] Changelog updated
- [x] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
