### PR TITLE
Feature/enable nav logic for all post types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+### Changed
+
+- Chapter navigation now supports all post types instead of long-read only
+
 ## [v2.1.0] - 2026-04-01
 
 ### Added

--- a/spec/chapter_navigation.spec.php
+++ b/spec/chapter_navigation.spec.php
@@ -8,7 +8,7 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 	});
 
 	describe('->getItems()', function () {
-		context('global post is the parent long-read post', function () {
+		context('global post is a parent post', function () {
 			it('returns an array of items with the first item as the current post, which will have a null url property', function () {
 				global $post;
 				$post = (object) [
@@ -28,7 +28,7 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 				]);
 				expect('get_posts')->toBeCalled()->once()->with([
 					'post_parent' => 123,
-					'post_type' => 'long-read',
+					'post_type' => 'any',
 					'posts_per_page' => -1,
 					'orderby' => 'menu_order',
 					'order' => 'ASC'
@@ -47,7 +47,7 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 			});
 		});
 
-		context('global post is a child long-read post', function () {
+		context('global post is a child post', function () {
 			it('returns an array of items with the current post in the appropriate place, and with a null url property', function () {
 				global $post;
 				$post = (object) [
@@ -71,7 +71,7 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 				]);
 				expect('get_posts')->toBeCalled()->once()->with([
 					'post_parent' => 123,
-					'post_type' => 'long-read',
+					'post_type' => 'any',
 					'posts_per_page' => -1,
 					'orderby' => 'menu_order',
 					'order' => 'ASC'

--- a/src/ChapterNavigation.php
+++ b/src/ChapterNavigation.php
@@ -11,7 +11,7 @@ class ChapterNavigation
 		$parentPost = $potentialParent ? $potentialParent : $post;
 		$chapterPosts = get_posts([
 			'post_parent' => $parentPost->ID,
-			'post_type' => 'long-read',
+			'post_type' => 'any',
 			'posts_per_page' => -1,
 			'orderby' => 'menu_order',
 			'order' => 'ASC'


### PR DESCRIPTION
## Description of changes
This PR updates the chapter navigation to support all post types instead of being hardcoded to `long-read`. This is done by using `post_type => 'any'` in the `get_posts` query, which allows the plugin to work across all post types.

### To test

1. Install this plugin into a site repo and fetch this branch `feature/enable-nav-logic-for-all-post-types`.
2. In this branch, copy the example template [here](https://github.com/dxw/long-read-plugin/blob/main/template/single-long-read.php) into your site repo `templates` folder.
3. In admin, activate the plugin and check the `Long read` post type is available, and create a new long read post with some `heading` blocks at various levels. (Might need to flush permalinks in Settings > Permalinks `save`).
4. View the post, check that the long read navigation still renders on the page.
5. To check the navigation functionality is working for other post types, add this  or similar to your template:
```
/**
 * Template Name: Long Read
 * Template Post Type: post, page, guidance, long-read
 */
 ```
 6. On your chosen post type, create a new post similar to the one you created for the `long-read` post type and check that it renders the navigation functionality.
 7. Check that it is not made available for other post types.

## Checklist
- [x] Changelog updated
- [ ] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
