### PR TITLE
Feature/enable chapter nav for drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Chapter navigation now includes draft posts for users with edit permissions
+
 ## [v2.2.0] - 2026-04-07
 
 ### Changed

--- a/spec/chapter_navigation.spec.php
+++ b/spec/chapter_navigation.spec.php
@@ -15,6 +15,7 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 					'ID' => 123,
 					'post_title' => 'Chapter One'
 				];
+				allow('current_user_can')->toBeCalled();
 				allow('get_post_parent')->toBeCalled()->andReturn(false);
 				allow('get_posts')->toBeCalled()->andReturn([
 					(object) [
@@ -28,6 +29,7 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 				]);
 				expect('get_posts')->toBeCalled()->once()->with([
 					'post_parent' => 123,
+					'post_status' => ['publish'],
 					'post_type' => 'any',
 					'posts_per_page' => -1,
 					'orderby' => 'menu_order',
@@ -58,6 +60,7 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 					'ID' => 123,
 					'post_title' => 'Chapter One'
 				];
+				allow('current_user_can')->toBeCalled();
 				allow('get_post_parent')->toBeCalled()->andReturn($parentPost);
 				allow('get_posts')->toBeCalled()->andReturn([
 					$post = (object) [
@@ -71,6 +74,7 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 				]);
 				expect('get_posts')->toBeCalled()->once()->with([
 					'post_parent' => 123,
+					'post_status' => ['publish'],
 					'post_type' => 'any',
 					'posts_per_page' => -1,
 					'orderby' => 'menu_order',
@@ -87,6 +91,48 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 				expect($result[1]->url)->toEqual(null);
 				expect($result[2]->title)->toEqual('Chapter Three');
 				expect($result[2]->url)->toEqual('http://chapter-three-link');
+			});
+		});
+
+		context('when the current logged in user can edit posts', function () {
+			it('includes draft posts in the query and returns them in the result', function () {
+				global $post;
+				$post = (object) [
+					'ID' => 1011,
+					'post_title' => 'Chapter Four'
+				];
+				$parentPost = (object) [
+					'ID' => 123,
+					'post_title' => 'Chapter One',
+					'post_status' => 'publish'
+				];
+				allow('current_user_can')->toBeCalled()->andReturn(true);
+				allow('get_post_parent')->toBeCalled()->andReturn($parentPost);
+				allow('get_posts')->toBeCalled()->andReturn([
+					(object) [
+						'ID' => 456,
+						'post_title' => 'Chapter Two',
+						'post_status' => 'publish'
+					],
+					(object) [
+						'ID' => 789,
+						'post_title' => 'Chapter Three',
+						'post_status' => 'draft'
+					]
+				]);
+				expect('get_posts')->toBeCalled()->once()->with([
+					'post_parent' => 123,
+					'post_status' => ['publish', 'draft'],
+					'post_type' => 'any',
+					'posts_per_page' => -1,
+					'orderby' => 'menu_order',
+					'order' => 'ASC'
+				]);
+				allow('get_permalink')->toBeCalled();
+
+				$result = $this->chapterNavigation->getItems();
+
+				expect(count($result))->toEqual(3);
 			});
 		});
 	});

--- a/src/ChapterNavigation.php
+++ b/src/ChapterNavigation.php
@@ -6,11 +6,16 @@ class ChapterNavigation
 {
 	public function getItems(): array
 	{
+		$postStatus = ['publish'];
+		if(current_user_can('edit_posts')) {
+			array_push($postStatus, 'draft');
+		}
 		global $post;
 		$potentialParent = get_post_parent($post);
 		$parentPost = $potentialParent ? $potentialParent : $post;
 		$chapterPosts = get_posts([
 			'post_parent' => $parentPost->ID,
+			'post_status' => $postStatus,
 			'post_type' => 'any',
 			'posts_per_page' => -1,
 			'orderby' => 'menu_order',


### PR DESCRIPTION
## Description of changes

This PR changes `ChapterNavigation->getItems` to also get draft posts for users that have the `edit_posts` capability so that drafts that are in preview can show their full chapter/page navigation of all posts related to each other.

To test:
1. Fetch this branch `feature/enable-chapter-nav-for-drafts`.
2. In admin create some users that can edit posts and optionally a subscriber.
3. Create some draft posts and set a parent for them. Use the Preview link in the editor to view the draft and check that it displays all chapters in the page nav as a user who can edit posts. 
4. Publish a post, the post should still display all posts.
5. Switch to a user that can't edit posts or log out of current user and check the published post again. It should only show chapters of published posts.

## Checklist
- [x] Changelog updated
- [ ] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
