### PR TITLE
Add filter for allowed nav item post status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Filter replaces hard-coded addition of draft posts to navigation
+
 ## [v2.3.0] - 2026-04-29
 
 ### Changed

--- a/spec/chapter_navigation.spec.php
+++ b/spec/chapter_navigation.spec.php
@@ -15,7 +15,7 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 					'ID' => 123,
 					'post_title' => 'Chapter One'
 				];
-				allow('current_user_can')->toBeCalled();
+				allow('apply_filters')->toBeCalled()->andReturn(['publish']);
 				allow('get_post_parent')->toBeCalled()->andReturn(false);
 				allow('get_posts')->toBeCalled()->andReturn([
 					(object) [
@@ -27,6 +27,7 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 						'post_title' => 'Chapter Three'
 					],
 				]);
+				expect('apply_filters')->toBeCalled()->once()->with('long_read_plugin_post_status', ['publish']);
 				expect('get_posts')->toBeCalled()->once()->with([
 					'post_parent' => 123,
 					'post_status' => ['publish'],
@@ -60,7 +61,7 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 					'ID' => 123,
 					'post_title' => 'Chapter One'
 				];
-				allow('current_user_can')->toBeCalled();
+				allow('apply_filters')->toBeCalled()->andReturn(['publish']);
 				allow('get_post_parent')->toBeCalled()->andReturn($parentPost);
 				allow('get_posts')->toBeCalled()->andReturn([
 					$post = (object) [
@@ -72,6 +73,7 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 						'post_title' => 'Chapter Three'
 					]
 				]);
+				expect('apply_filters')->toBeCalled()->once()->with('long_read_plugin_post_status', ['publish']);
 				expect('get_posts')->toBeCalled()->once()->with([
 					'post_parent' => 123,
 					'post_status' => ['publish'],
@@ -94,8 +96,8 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 			});
 		});
 
-		context('when the current logged in user can edit posts', function () {
-			it('includes draft posts in the query and returns them in the result', function () {
+		context('when long read post status filter includes drafts', function () {
+			it('queries with filtered post statuses and returns those posts', function () {
 				global $post;
 				$post = (object) [
 					'ID' => 1011,
@@ -106,7 +108,7 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 					'post_title' => 'Chapter One',
 					'post_status' => 'publish'
 				];
-				allow('current_user_can')->toBeCalled()->andReturn(true);
+				allow('apply_filters')->toBeCalled()->andReturn(['publish', 'draft']);
 				allow('get_post_parent')->toBeCalled()->andReturn($parentPost);
 				allow('get_posts')->toBeCalled()->andReturn([
 					(object) [
@@ -120,6 +122,7 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 						'post_status' => 'draft'
 					]
 				]);
+				expect('apply_filters')->toBeCalled()->once()->with('long_read_plugin_post_status', ['publish']);
 				expect('get_posts')->toBeCalled()->once()->with([
 					'post_parent' => 123,
 					'post_status' => ['publish', 'draft'],

--- a/src/ChapterNavigation.php
+++ b/src/ChapterNavigation.php
@@ -7,7 +7,7 @@ class ChapterNavigation
 	public function getItems(): array
 	{
 		$postStatus = apply_filters('long_read_plugin_post_status', ['publish']);
-		
+
 		global $post;
 		$potentialParent = get_post_parent($post);
 		$parentPost = $potentialParent ? $potentialParent : $post;

--- a/src/ChapterNavigation.php
+++ b/src/ChapterNavigation.php
@@ -6,10 +6,8 @@ class ChapterNavigation
 {
 	public function getItems(): array
 	{
-		$postStatus = ['publish'];
-		if(current_user_can('edit_posts')) {
-			array_push($postStatus, 'draft');
-		}
+		$postStatus = apply_filters('long_read_plugin_post_status', ['publish']);
+		
 		global $post;
 		$potentialParent = get_post_parent($post);
 		$parentPost = $potentialParent ? $potentialParent : $post;


### PR DESCRIPTION
## Description of changes
This PR replaces the hard-coded addition of 'draft' to the status of posts allowed to appear in the long read nav, with a filter.
So, in a child theme or plugin the draft status can be added.

To test: Create a new style long read post. Add a draft article as a child of that post. It should not appear in the navigation.
Now, add this code to functions.php

`add_filter('long_read_plugin_post_status', function($postStatus) {
	array_push($postStatus, 'draft');
	return $postStatus;
});`

The draft article should now appear in the navigation, even for logged out users.

This is the second item of this card: https://trello.com/c/vjzEsXkS/337-enable-public-previews-for-content-including-long-reads

## Checklist
- [x] Changelog updated
- [ ] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
