### PR TITLE
Feature/filter nav urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Filter replaces hard-coded addition of draft posts to navigation
+- Filter url passed to chapter navigation items
 
 ## [v2.3.0] - 2026-04-29
 

--- a/spec/chapter_navigation.spec.php
+++ b/spec/chapter_navigation.spec.php
@@ -1,7 +1,5 @@
 <?php
 
-use Kahlan\Arg;
-
 describe(\LongReadPlugin\ChapterNavigation::class, function () {
 	beforeEach(function () {
 		$this->chapterNavigation = new \LongReadPlugin\ChapterNavigation();
@@ -15,7 +13,18 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 					'ID' => 123,
 					'post_title' => 'Chapter One'
 				];
-				allow('apply_filters')->toBeCalled()->andReturn(['publish']);
+				$chapterUrlCallArgs = [];
+				allow('apply_filters')->toBeCalled()->andRun(function (string $filterName, $value, $chapterPostId = null) use (&$chapterUrlCallArgs) {
+					if ($filterName === 'long_read_plugin_post_status') {
+						return ['publish'];
+					}
+
+					if ($filterName === 'long_read_plugin_chapter_url') {
+						$chapterUrlCallArgs[] = $chapterPostId;
+					}
+
+					return $value;
+				});
 				allow('get_post_parent')->toBeCalled()->andReturn(false);
 				allow('get_posts')->toBeCalled()->andReturn([
 					(object) [
@@ -39,6 +48,9 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 				allow('get_permalink')->toBeCalled()->andReturn('http://chapter-two-link', 'http://chapter-three-link');
 
 				$result = $this->chapterNavigation->getItems();
+				expect($chapterUrlCallArgs[0])->toEqual(123);
+				expect($chapterUrlCallArgs[1])->toEqual(456);
+				expect($chapterUrlCallArgs[2])->toEqual(789);
 
 				expect(count($result))->toEqual(3);
 				expect($result[0]->title)->toEqual('Chapter One');
@@ -61,10 +73,21 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 					'ID' => 123,
 					'post_title' => 'Chapter One'
 				];
-				allow('apply_filters')->toBeCalled()->andReturn(['publish']);
+				$chapterUrlCallArgs = [];
+				allow('apply_filters')->toBeCalled()->andRun(function (string $filterName, $value, $chapterPostId = null) use (&$chapterUrlCallArgs) {
+					if ($filterName === 'long_read_plugin_post_status') {
+						return ['publish'];
+					}
+
+					if ($filterName === 'long_read_plugin_chapter_url') {
+						$chapterUrlCallArgs[] = $chapterPostId;
+					}
+
+					return $value;
+				});
 				allow('get_post_parent')->toBeCalled()->andReturn($parentPost);
 				allow('get_posts')->toBeCalled()->andReturn([
-					$post = (object) [
+					(object) [
 						'ID' => 456,
 						'post_title' => 'Chapter Two'
 					],
@@ -85,6 +108,9 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 				allow('get_permalink')->toBeCalled()->andReturn('http://chapter-one-link', 'http://chapter-three-link');
 
 				$result = $this->chapterNavigation->getItems();
+				expect($chapterUrlCallArgs[0])->toEqual(123);
+				expect($chapterUrlCallArgs[1])->toEqual(456);
+				expect($chapterUrlCallArgs[2])->toEqual(789);
 
 				expect(count($result))->toEqual(3);
 				expect($result[0]->title)->toEqual('Chapter One');
@@ -108,7 +134,13 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 					'post_title' => 'Chapter One',
 					'post_status' => 'publish'
 				];
-				allow('apply_filters')->toBeCalled()->andReturn(['publish', 'draft']);
+				allow('apply_filters')->toBeCalled()->andRun(function (string $filterName, $value) {
+					if ($filterName === 'long_read_plugin_post_status') {
+						return ['publish', 'draft'];
+					}
+
+					return $value;
+				});
 				allow('get_post_parent')->toBeCalled()->andReturn($parentPost);
 				allow('get_posts')->toBeCalled()->andReturn([
 					(object) [
@@ -136,6 +168,42 @@ describe(\LongReadPlugin\ChapterNavigation::class, function () {
 				$result = $this->chapterNavigation->getItems();
 
 				expect(count($result))->toEqual(3);
+			});
+		});
+
+		context('when long read chapter URL filter changes an item URL', function () {
+			it('returns the filtered chapter URL in the navigation item', function () {
+				global $post;
+				$post = (object) [
+					'ID' => 123,
+					'post_title' => 'Chapter One'
+				];
+				allow('apply_filters')->toBeCalled()->andRun(function (string $filterName, $value, $chapterPostId = null) {
+					if ($filterName === 'long_read_plugin_post_status') {
+						return ['publish'];
+					}
+
+					if (
+						$filterName === 'long_read_plugin_chapter_url'
+						&& $chapterPostId === 456
+					) {
+						return 'http://filtered-chapter-two-link';
+					}
+
+					return $value;
+				});
+				allow('get_post_parent')->toBeCalled()->andReturn(false);
+				allow('get_posts')->toBeCalled()->andReturn([
+					(object) [
+						'ID' => 456,
+						'post_title' => 'Chapter Two'
+					]
+				]);
+				allow('get_permalink')->toBeCalled()->andReturn('http://chapter-two-link');
+
+				$result = $this->chapterNavigation->getItems();
+
+				expect($result[1]->url)->toEqual('http://filtered-chapter-two-link');
 			});
 		});
 	});

--- a/src/ChapterNavigation.php
+++ b/src/ChapterNavigation.php
@@ -20,11 +20,12 @@ class ChapterNavigation
 			'order' => 'ASC'
 		]);
 		array_unshift($chapterPosts, $parentPost);
+		$currentPostId = $post->ID;
 		$chapterNavigationItems = [];
 		foreach ($chapterPosts as $chapterPost) {
 			$chapterNavigationItems[] = (object) [
 				'title' => $chapterPost->post_title,
-				'url' => $chapterPost->ID == $post->ID ? null : get_permalink($chapterPost)
+				'url' => apply_filters('long_read_plugin_chapter_url', $chapterPost->ID == $currentPostId ? null : get_permalink($chapterPost), $chapterPost->ID)
 			];
 		}
 		return $chapterNavigationItems;


### PR DESCRIPTION
## Description of changes
This PR adds a filter to the url passed to each chapter navigation item. It's purpose is to allow a custom value, such as a preview link open to non logged-in users, to be output.

To test it works, open a long read with several child pages. Paste something like the following into templates/functions.php

`add_filter('long_read_plugin_chapter_url', function($url, $postID) {
if ($url) {
return 'https://bbc.co.uk/';
}
return $url;
}, 10, 2);`

All the links in the nav should now go to bbc Remove the code and the links should go to their expected destination. 

If you use the code above the pagination links will disappear because there will be no

## Checklist
- [x] Changelog updated
- [ ] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
