### PR TITLE
Fix/do not assume acf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
@@ -40,10 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Composer dependencies updated
 - Scripts to rule them all pattern implemented
 
-
 ## [v2.0.1] - 2025-07-22
 
 ### Changed
+
 - TOC generator skips empty heading blocks
 
 ## [v2.0.0] - 2025-03-25
@@ -54,32 +56,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - PHP 7.4 is deprecated and will no longer be tested against.
 
 ## [1.1.3] - 2024-07-18
+
 ### Added
+
 - PR template
 
 ## [1.1.2] - 2022-12-2
+
 ### Amended
+
 - Add headings from within block groups to in-page navigation
 
 ## [1.1.1] - 2022-09-08
+
 ### Amended
-- Changed regex generating in-page anchors to use a non-greedy regex to eliminate issues with pasted in styling
+
+- Changed regex generating in-page anchors to use a non-greedy regex to
+  eliminate issues with pasted in styling
 
 ## [1.1.0] - 2022-08-15
+
 ### Added
-- `\LongReadPlugin\ParentTitle::get()` to return title of top-level long-read item
+
+- `\LongReadPlugin\ParentTitle::get()` to return title of top-level long-read
+  item
 
 ## [1.0.3] - 2022-05-27
+
 ### Amended
+
 - Ensure heading anchors are generated in WordPress v6.0
 
 ## [1.0.2] - 2022-05-26
+
 ### Amended
-- Ensure block editor is enforced, even if an individual user has chosen "classic" as their preferred editor in the classic editor plugin
+
+- Ensure block editor is enforced, even if an individual user has chosen
+  "classic" as their preferred editor in the classic editor plugin
 
 ## [1.0.1] - 2022-05-19
+
 ### Amended
+
 - Allow for possible null in call to `use_block_editor_for_post_type` filter
 
 ## [1.0.0] - 2022-05-19
+
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Do not assume ACF is active when checking if post type is disabled
+
 ## [v2.4.0] - 2026-05-15
 
 ### Changed

--- a/spec/post_type.spec.php
+++ b/spec/post_type.spec.php
@@ -25,13 +25,21 @@ describe(\LongReadPlugin\PostType::class, function () {
 	});
 
 	describe('->registerPostType()', function () {
+		it('registers the post type if ACF is disabled', function () {
+			allow('function_exists')->toBeCalled()->andReturn(false);
+			allow('register_post_type')->toBeCalled();
+			expect('register_post_type')->toBeCalled()->once()->with(Arg::toBeA('string'), Arg::toBeAn('array'));
+			$this->postType->registerPostType();
+		});
 		it('registers the post type', function () {
+			allow('function_exists')->toBeCalled()->andReturn(true);
 			allow('register_post_type')->toBeCalled();
 			allow('get_field')->toBeCalled()->andReturn(false);
 			expect('register_post_type')->toBeCalled()->once()->with(Arg::toBeA('string'), Arg::toBeAn('array'));
 			$this->postType->registerPostType();
 		});
 		it('does not register the post type if the option is set to deactivate it', function () {
+			allow('function_exists')->toBeCalled()->andReturn(true);
 			allow('register_post_type')->toBeCalled();
 			allow('get_field')->toBeCalled()->andReturn(true);
 			expect('register_post_type')->not->toBeCalled();

--- a/src/PostType.php
+++ b/src/PostType.php
@@ -23,7 +23,7 @@ class PostType implements \Dxw\Iguana\Registerable
 			$deactivatePostType = get_field('long_read_plugin_toggle_post_type', 'option');
 		}
 
-		if (!$deactivatePostType) {
+		if ($deactivatePostType !== true) {
 			register_post_type('long-read', [
 				'label' => 'Long Reads',
 				'labels' => [

--- a/src/PostType.php
+++ b/src/PostType.php
@@ -18,8 +18,10 @@ class PostType implements \Dxw\Iguana\Registerable
 
 	public function registerPostType(): void
 	{
-		/** @var bool $activatePostType */
-		$deactivatePostType = get_field('long_read_plugin_toggle_post_type', 'option');
+		$deactivatePostType = false;
+		if (function_exists('get_field')) {
+			$deactivatePostType = get_field('long_read_plugin_toggle_post_type', 'option');
+		}
 
 		if (!$deactivatePostType) {
 			register_post_type('long-read', [


### PR DESCRIPTION
This PR ensures that we check ACF is active before calling `get_field()`. It also tightens the boolean check of the returned value, to satisfy Psalm.

## How to test

1. On a site where this branch of the plugin is active, deactivate ACF. You should not get any fatal errors.
2. Confirm that toggling the default post type on/off works as expected.

## Checklist
- [x] Changelog updated
- [ ] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
