### PR TITLE
Chore/433 nav interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Changed
 
 - Use custom classes for navigation data
+- Create interfaces for page navigation
 
 ## [v2.4.1] - 2026-05-28
 

--- a/spec/chapter_navigation.spec.php
+++ b/spec/chapter_navigation.spec.php
@@ -1,8 +1,8 @@
 <?php
 
-describe(\LongReadPlugin\ChapterNavigation::class, function () {
+describe(\LongReadPlugin\HierarchicalChapterNavigation::class, function () {
 	beforeEach(function () {
-		$this->chapterNavigation = new \LongReadPlugin\ChapterNavigation();
+		$this->chapterNavigation = new \LongReadPlugin\HierarchicalChapterNavigation();
 	});
 
 	describe('->getItems()', function () {

--- a/spec/chapter_navigation_interface.spec.php
+++ b/spec/chapter_navigation_interface.spec.php
@@ -1,0 +1,17 @@
+<?php
+
+describe(\LongReadPlugin\ChapterNavigationInterface::class, function () {
+	it('defines a getItems method', function () {
+		$reflection = new ReflectionClass(\LongReadPlugin\ChapterNavigationInterface::class);
+		expect($reflection->hasMethod('getItems'))->toEqual(true);
+	});
+
+	it('specifies getItems returns an array', function () {
+		$reflection = new ReflectionClass(\LongReadPlugin\ChapterNavigationInterface::class);
+		$method = $reflection->getMethod('getItems');
+		$returnType = $method->getReturnType();
+
+		expect($returnType)->not->toBeNull();
+		expect($returnType->getName())->toEqual('array');
+	});
+});

--- a/spec/in_page_navigation.spec.php
+++ b/spec/in_page_navigation.spec.php
@@ -1,8 +1,8 @@
 <?php
 
-describe(LongReadPlugin\InPageNavigation::class, function () {
+describe(LongReadPlugin\HierarchicalInPageNavigation::class, function () {
 	beforeEach(function () {
-		$this->inPageNavigation = new \LongReadPlugin\InPageNavigation();
+		$this->inPageNavigation = new \LongReadPlugin\HierarchicalInPageNavigation();
 	});
 
 	describe('->getItems()', function () {
@@ -88,10 +88,10 @@ describe(LongReadPlugin\InPageNavigation::class, function () {
 			$result = $this->inPageNavigation->getItems();
 
 			expect(count($result))->toEqual(2);
-		expect($result[0])->toBeAnInstanceOf(\LongReadPlugin\InPageNavigationItem::class);
-		expect($result[0]->title)->toEqual("First heading");
-		expect($result[0]->id)->toEqual('first-heading');
-		expect($result[1])->toBeAnInstanceOf(\LongReadPlugin\InPageNavigationItem::class);
+			expect($result[0])->toBeAnInstanceOf(\LongReadPlugin\InPageNavigationItem::class);
+			expect($result[0]->title)->toEqual("First heading");
+			expect($result[0]->id)->toEqual('first-heading');
+			expect($result[1])->toBeAnInstanceOf(\LongReadPlugin\InPageNavigationItem::class);
 			expect($result[1]->title)->toEqual("Second heading");
 			expect($result[1]->id)->toEqual('second-heading');
 		});
@@ -116,7 +116,9 @@ describe(LongReadPlugin\InPageNavigation::class, function () {
 
 			$result = $this->inPageNavigation->getItems();
 
-			expect(count($result))->toEqual(1);		expect($result[0])->toBeAnInstanceOf(\LongReadPlugin\InPageNavigationItem::class);			expect($result[0]->title)->toEqual("First heading");
+			expect(count($result))->toEqual(1);
+			expect($result[0])->toBeAnInstanceOf(\LongReadPlugin\InPageNavigationItem::class);
+			expect($result[0]->title)->toEqual("First heading");
 			expect($result[0]->id)->toEqual('first-heading');
 		});
 	});

--- a/spec/in_page_navigation_interface.spec.php
+++ b/spec/in_page_navigation_interface.spec.php
@@ -1,0 +1,17 @@
+<?php
+
+describe(\LongReadPlugin\InPageNavigationInterface::class, function () {
+	it('defines a getItems method', function () {
+		$reflection = new ReflectionClass(\LongReadPlugin\InPageNavigationInterface::class);
+		expect($reflection->hasMethod('getItems'))->toEqual(true);
+	});
+
+	it('specifies getItems returns an array', function () {
+		$reflection = new ReflectionClass(\LongReadPlugin\InPageNavigationInterface::class);
+		$method = $reflection->getMethod('getItems');
+		$returnType = $method->getReturnType();
+
+		expect($returnType)->not->toBeNull();
+		expect($returnType->getName())->toEqual('array');
+	});
+});

--- a/spec/navigation.spec.php
+++ b/spec/navigation.spec.php
@@ -13,8 +13,8 @@ describe(LongReadPlugin\Navigation::class, function () {
 		});
 
 		it('returns an array of items where the in page nav is mapped to the subItems property of the current post item in the chapter nav items', function () {
-			$this->chapterNavigation = Double::instance(['extends' => '\LongReadPlugin\ChapterNavigation']);
-			$this->inPageNavigation = Double::instance(['extends' => '\LongReadPlugin\InPageNavigation']);
+			$this->chapterNavigation = Double::instance(['extends' => '\LongReadPlugin\HierarchicalChapterNavigation']);
+			$this->inPageNavigation = Double::instance(['extends' => '\LongReadPlugin\HierarchicalInPageNavigation']);
 			allow($this->chapterNavigation)->toReceive('getItems')->andReturn([
 				(object) [
 					'title' => 'Chapter One',

--- a/src/ChapterNavigationInterface.php
+++ b/src/ChapterNavigationInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace LongReadPlugin;
+
+interface ChapterNavigationInterface
+{
+	public function getItems(): array;
+}

--- a/src/ChapterNavigationInterface.php
+++ b/src/ChapterNavigationInterface.php
@@ -4,5 +4,6 @@ namespace LongReadPlugin;
 
 interface ChapterNavigationInterface
 {
+	/** @return ChapterNavigationItem[] */
 	public function getItems(): array;
 }

--- a/src/ChapterNavigationItem.php
+++ b/src/ChapterNavigationItem.php
@@ -6,6 +6,7 @@ class ChapterNavigationItem
 {
 	public readonly string $title;
 	public readonly ?string $url;
+	public array $subItems = [];
 
 	public function __construct(string $title, ?string $url)
 	{

--- a/src/HierarchicalChapterNavigation.php
+++ b/src/HierarchicalChapterNavigation.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace LongReadPlugin ;
+namespace LongReadPlugin;
 
-class ChapterNavigation
+class HierarchicalChapterNavigation implements ChapterNavigationInterface
 {
 	public function getItems(): array
 	{

--- a/src/HierarchicalInPageNavigation.php
+++ b/src/HierarchicalInPageNavigation.php
@@ -2,7 +2,7 @@
 
 namespace LongReadPlugin;
 
-class InPageNavigation
+class HierarchicalInPageNavigation implements InPageNavigationInterface
 {
 	/** @var array $inPageNavItems */
 	private $inPageNavItems = [];

--- a/src/InPageNavigationInterface.php
+++ b/src/InPageNavigationInterface.php
@@ -4,5 +4,6 @@ namespace LongReadPlugin;
 
 interface InPageNavigationInterface
 {
+	/** @return InPageNavigationItem[] */
 	public function getItems(): array;
 }

--- a/src/InPageNavigationInterface.php
+++ b/src/InPageNavigationInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace LongReadPlugin;
+
+interface InPageNavigationInterface
+{
+	public function getItems(): array;
+}

--- a/src/Navigation.php
+++ b/src/Navigation.php
@@ -4,10 +4,10 @@ namespace LongReadPlugin;
 
 class Navigation
 {
-	private static ChapterNavigation $chapterNavigation;
-	private static InPageNavigation $inPageNavigation;
+	private static ChapterNavigationInterface $chapterNavigation;
+	private static InPageNavigationInterface $inPageNavigation;
 
-	public function __construct(ChapterNavigation $chapterNavigation, InPageNavigation $inPageNavigation)
+	public function __construct(ChapterNavigationInterface $chapterNavigation, InPageNavigationInterface $inPageNavigation)
 	{
 		static::$chapterNavigation = $chapterNavigation;
 		static::$inPageNavigation = $inPageNavigation;

--- a/src/di.php
+++ b/src/di.php
@@ -3,8 +3,8 @@
 $registrar->addInstance(new \LongReadPlugin\PostType());
 $registrar->addInstance(new \LongReadPlugin\HeadingAnchors());
 $registrar->addInstance(new \LongReadPlugin\Navigation(
-	new LongReadPlugin\ChapterNavigation(),
-	new LongReadPlugin\InPageNavigation()
+	new LongReadPlugin\HierarchicalChapterNavigation(),
+	new LongReadPlugin\HierarchicalInPageNavigation()
 ));
 $registrar->addInstance(new \LongReadPlugin\Options());
 $registrar->addInstance(new \LongReadPlugin\Template());


### PR DESCRIPTION
## Description of changes

Introduces interfaces in place of navigation classes. Calls to classes within Navigation.php are replaced with calls to the interface. This will allow us to have multiple implementations of the navigation while keeping the basic structure. 

To this end the navigation classes are renamed to illustrate that they are children of the interface parents that focus on a particular functional approach - in this case using page hierarchy to generate nav items.

Tests are updated and new tests added for the interfaces.
...

## Checklist
- [x] Changelog updated
- [ ] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
