### PR TITLE
Feature/436 page break chapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 ### Added
 
 - Page break in page navigation functionality
+- Page break chapter navigation
 
 ## [v2.4.1] - 2026-05-28
 

--- a/spec/page_break_chapter_navigation.spec.php
+++ b/spec/page_break_chapter_navigation.spec.php
@@ -5,12 +5,51 @@ describe(\LongReadPlugin\PageBreakChapterNavigation::class, function () {
 		$this->navigation = new \LongReadPlugin\PageBreakChapterNavigation();
 	});
 	describe('::getItems()', function () {
+		beforeEach(function () {
+			global $post;
+			$post = (object) [
+				'ID' => 123,
+				'post_content' => '<h2>Chapter 1</h2><!--nextpage--><h2>Chapter 2</h2>'
+			];
+
+			allow('apply_filters')->toBeCalled()->andRun(function ($filterName, $value) {
+				return $value;
+			});
+			allow('get_permalink')->toBeCalled()->andReturn('/long-read/');
+		});
+
 		it('returns an array of chapter navigation items', function () {
-			$item = new \LongReadPlugin\ChapterNavigationItem('Chapter 1', '/chapter-1');
-			allow('apply_filters')->toBeCalled()->andReturn('Chapter 1', '/chapter-1');
+			$item = new \LongReadPlugin\ChapterNavigationItem('Chapter 1', null);
+			allow('get_query_var')->toBeCalled()->with('page', 1)->andReturn(1);
 			$result = $this->navigation->getItems();
 
-			expect($result)->toEqual([$item]);
+			expect($result[0])->toEqual($item);
+		});
+		it('returns an empty array when no chapters are found', function () {
+			global $post;
+			$post->post_content = '';
+			allow('get_query_var')->toBeCalled()->with('page', 1)->andReturn(1);
+			$result = $this->navigation->getItems();
+
+			expect($result)->toEqual([]);
+		});
+		it('returns an array with multiple chapters when multiple page breaks are found', function () {
+			$chapter1 = new \LongReadPlugin\ChapterNavigationItem('Chapter 1', null);
+			$chapter2 = new \LongReadPlugin\ChapterNavigationItem('Chapter 2', '/long-read/2/');
+			allow('get_query_var')->toBeCalled()->with('page', 1)->andReturn(1);
+			$result = $this->navigation->getItems();
+
+			expect($result)->toEqual([$chapter1, $chapter2]);
+		});
+
+		it('sets current chapter url to null when viewing page 2', function () {
+			allow('get_query_var')->toBeCalled()->with('page', 1)->andReturn(2);
+
+			$result = $this->navigation->getItems();
+
+			expect(count($result))->toEqual(2);
+			expect($result[0]->url)->toEqual('/long-read/');
+			expect($result[1]->url)->toBeNull();
 		});
 	});
 });

--- a/spec/page_break_chapter_navigation.spec.php
+++ b/spec/page_break_chapter_navigation.spec.php
@@ -1,0 +1,16 @@
+<?php
+
+describe(\LongReadPlugin\PageBreakChapterNavigation::class, function () {
+	beforeEach(function () {
+		$this->navigation = new \LongReadPlugin\PageBreakChapterNavigation();
+	});
+	describe('::getItems()', function () {
+		it('returns an array of chapter navigation items', function () {
+			$item = new \LongReadPlugin\ChapterNavigationItem('Chapter 1', '/chapter-1');
+			allow('apply_filters')->toBeCalled()->andReturn('Chapter 1', '/chapter-1');
+			$result = $this->navigation->getItems();
+
+			expect($result)->toEqual([$item]);
+		});
+	});
+});

--- a/spec/page_break_chapter_navigation.spec.php
+++ b/spec/page_break_chapter_navigation.spec.php
@@ -42,8 +42,7 @@ describe(\LongReadPlugin\PageBreakChapterNavigation::class, function () {
 			$chapter1 = new \LongReadPlugin\ChapterNavigationItem('Chapter 1', null);
 			$chapter2 = new \LongReadPlugin\ChapterNavigationItem('Chapter 2', '/long-read/2/');
 			allow('get_query_var')->toBeCalled()->with('page', 1)->andReturn(1);
-			expect('apply_filters')->toBeCalled()->times(3);
-			expect('apply_filters')->toBeCalled()->with('the_content', '<h2>Chapter 1</h2><!--nextpage--><h2>Chapter 2</h2>');
+			expect('apply_filters')->toBeCalled()->times(2);
 			expect('apply_filters')->toBeCalled()->with('long_read_plugin_chapter_url', null, 123);
 			expect('apply_filters')->toBeCalled()->with('long_read_plugin_chapter_url', '/long-read/2/', 123);
 			$result = $this->navigation->getItems();

--- a/spec/page_break_chapter_navigation.spec.php
+++ b/spec/page_break_chapter_navigation.spec.php
@@ -4,6 +4,11 @@ describe(\LongReadPlugin\PageBreakChapterNavigation::class, function () {
 	beforeEach(function () {
 		$this->navigation = new \LongReadPlugin\PageBreakChapterNavigation();
 	});
+
+	it('implements the ChapterNavigationInterface', function () {
+		expect($this->navigation)->toBeAnInstanceOf(\LongReadPlugin\ChapterNavigationInterface::class);
+	});
+
 	describe('::getItems()', function () {
 		beforeEach(function () {
 			global $post;
@@ -37,12 +42,16 @@ describe(\LongReadPlugin\PageBreakChapterNavigation::class, function () {
 			$chapter1 = new \LongReadPlugin\ChapterNavigationItem('Chapter 1', null);
 			$chapter2 = new \LongReadPlugin\ChapterNavigationItem('Chapter 2', '/long-read/2/');
 			allow('get_query_var')->toBeCalled()->with('page', 1)->andReturn(1);
+			expect('apply_filters')->toBeCalled()->times(3);
+			expect('apply_filters')->toBeCalled()->with('the_content', '<h2>Chapter 1</h2><!--nextpage--><h2>Chapter 2</h2>');
+			expect('apply_filters')->toBeCalled()->with('long_read_plugin_chapter_url', null, 123);
+			expect('apply_filters')->toBeCalled()->with('long_read_plugin_chapter_url', '/long-read/2/', 123);
 			$result = $this->navigation->getItems();
 
 			expect($result)->toEqual([$chapter1, $chapter2]);
 		});
 
-		it('sets current chapter url to null when viewing page 2', function () {
+		it('sets current chapter url to null', function () {
 			allow('get_query_var')->toBeCalled()->with('page', 1)->andReturn(2);
 
 			$result = $this->navigation->getItems();

--- a/spec/page_break_in_page_navigation.spec.php
+++ b/spec/page_break_in_page_navigation.spec.php
@@ -16,6 +16,38 @@ describe(LongReadPlugin\PageBreakInPageNavigation::class, function () {
 			allow('get_query_var')->toBeCalled()->with('page', 1)->andReturn(1);
 		});
 
+			it('returns only headings from the current page and does not retain previous page headings', function () {
+				global $post;
+				$post = (object) [
+					'post_content' => '<h2 id="page-one" class="wp-block-heading">Page one heading</h2><!--nextpage--><h2 id="page-two" class="wp-block-heading">Page two heading</h2>'
+				];
+
+				allow('get_query_var')->toBeCalled()->with('page', 1)->andReturn(1, 2);
+				allow('parse_blocks')->toBeCalled()->andRun(function (string $markup) {
+					if (strpos($markup, 'Page one heading') !== false) {
+						return [[
+							'blockName' => 'core/heading',
+							'attrs' => ['level' => 2],
+							'innerHTML' => '<h2 id="page-one" class="wp-block-heading">Page one heading</h2>'
+						]];
+					}
+
+					return [[
+						'blockName' => 'core/heading',
+						'attrs' => ['level' => 2],
+						'innerHTML' => '<h2 id="page-two" class="wp-block-heading">Page two heading</h2>'
+					]];
+				});
+
+				$pageOneResult = $this->inPageNavigation->getItems();
+				$pageTwoResult = $this->inPageNavigation->getItems();
+
+				expect(count($pageOneResult))->toEqual(1);
+				expect($pageOneResult[0]->id)->toEqual('page-one');
+				expect(count($pageTwoResult))->toEqual(1);
+				expect($pageTwoResult[0]->id)->toEqual('page-two');
+			});
+
 		it('returns an empty array when there are no headings on the current page', function () {
 			allow('parse_blocks')->toBeCalled()->andRun(function () {
 				return [];

--- a/spec/page_break_in_page_navigation.spec.php
+++ b/spec/page_break_in_page_navigation.spec.php
@@ -16,38 +16,6 @@ describe(LongReadPlugin\PageBreakInPageNavigation::class, function () {
 			allow('get_query_var')->toBeCalled()->with('page', 1)->andReturn(1);
 		});
 
-			it('returns only headings from the current page and does not retain previous page headings', function () {
-				global $post;
-				$post = (object) [
-					'post_content' => '<h2 id="page-one" class="wp-block-heading">Page one heading</h2><!--nextpage--><h2 id="page-two" class="wp-block-heading">Page two heading</h2>'
-				];
-
-				allow('get_query_var')->toBeCalled()->with('page', 1)->andReturn(1, 2);
-				allow('parse_blocks')->toBeCalled()->andRun(function (string $markup) {
-					if (strpos($markup, 'Page one heading') !== false) {
-						return [[
-							'blockName' => 'core/heading',
-							'attrs' => ['level' => 2],
-							'innerHTML' => '<h2 id="page-one" class="wp-block-heading">Page one heading</h2>'
-						]];
-					}
-
-					return [[
-						'blockName' => 'core/heading',
-						'attrs' => ['level' => 2],
-						'innerHTML' => '<h2 id="page-two" class="wp-block-heading">Page two heading</h2>'
-					]];
-				});
-
-				$pageOneResult = $this->inPageNavigation->getItems();
-				$pageTwoResult = $this->inPageNavigation->getItems();
-
-				expect(count($pageOneResult))->toEqual(1);
-				expect($pageOneResult[0]->id)->toEqual('page-one');
-				expect(count($pageTwoResult))->toEqual(1);
-				expect($pageTwoResult[0]->id)->toEqual('page-two');
-			});
-
 		it('returns an empty array when there are no headings on the current page', function () {
 			allow('parse_blocks')->toBeCalled()->andRun(function () {
 				return [];

--- a/src/PageBreakChapterNavigation.php
+++ b/src/PageBreakChapterNavigation.php
@@ -20,7 +20,7 @@ class PageBreakChapterNavigation implements ChapterNavigationInterface
 		$currentPage = max(1, (int) get_query_var('page', 1));
 		$pages = $this->getPages();
 		$permalink = get_permalink($post);
-		$normalizedPermalink = rtrim((string) $permalink, '/');
+		$whiteSpaceFreePermalink = rtrim((string) $permalink, '/');
 		foreach ($pages as $pageIndex => $page) {
 			$regexPattern = "~(<h([2-6]))(.*?>(.*)<\/h[2-6]>)~";
 			preg_match_all($regexPattern, $page, $matches);
@@ -31,7 +31,7 @@ class PageBreakChapterNavigation implements ChapterNavigationInterface
 			$chapterPage = $pageIndex + 1;
 			$chapterUrl = null;
 			if ($chapterPage !== $currentPage) {
-				$chapterUrl = $chapterPage === 1 ? $normalizedPermalink . '/' : $normalizedPermalink . '/' . $chapterPage . '/';
+				$chapterUrl = $chapterPage === 1 ? $whiteSpaceFreePermalink . '/' : $whiteSpaceFreePermalink . '/' . $chapterPage . '/';
 			}
 
 			$chapterNavigationItems[] = new ChapterNavigationItem(

--- a/src/PageBreakChapterNavigation.php
+++ b/src/PageBreakChapterNavigation.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LongReadPlugin;
+
+class PageBreakChapterNavigation implements ChapterNavigationInterface
+{
+	public function getItems(): array
+	{
+		$chapterNavigationItems = [];
+		$chapterNavigationItems[] = new ChapterNavigationItem(
+			apply_filters('long_read_plugin_chapter_title', 'Chapter 1'),
+			apply_filters('long_read_plugin_chapter_url', '/chapter-1')
+		);
+		return $chapterNavigationItems;
+	}
+}

--- a/src/PageBreakChapterNavigation.php
+++ b/src/PageBreakChapterNavigation.php
@@ -5,12 +5,33 @@ namespace LongReadPlugin;
 class PageBreakChapterNavigation implements ChapterNavigationInterface
 {
 	
-	public function getPages(): array
+	private function getPages(): array
 	{
 		global $post;
-		$fullContent = apply_filters('the_content', $post->post_content);
+		$fullContent = $post->post_content;
 		$pages = explode('<!--nextpage-->', $fullContent);
 		return $pages;
+	}
+
+	private function addNavigationItem(int $pageIndex, int $currentPage, string $page, string $permalink, int $postId): ?ChapterNavigationItem
+	{
+			
+		$matches = [];
+		preg_match('~<h([1-6])[^>]*>(.*?)</h\1>~is', $page, $matches);
+		if (empty($matches[0])) {
+			return null;
+		}
+
+		$chapterPage = $pageIndex + 1;
+		$chapterUrl = null;
+		if ($chapterPage !== $currentPage) {
+			$chapterUrl = $chapterPage === 1 ? $permalink . '/' : $permalink . '/' . $chapterPage . '/';
+		}
+
+		return new ChapterNavigationItem(
+			trim(strip_tags($matches[0])),
+			apply_filters('long_read_plugin_chapter_url', $chapterUrl, $postId)
+		);
 	}
 
 	public function getItems(): array
@@ -22,22 +43,10 @@ class PageBreakChapterNavigation implements ChapterNavigationInterface
 		$permalink = get_permalink($post);
 		$whiteSpaceFreePermalink = rtrim((string) $permalink, '/');
 		foreach ($pages as $pageIndex => $page) {
-			$regexPattern = "~(<h([2-6]))(.*?>(.*)<\/h[2-6]>)~";
-			preg_match_all($regexPattern, $page, $matches);
-			if (empty($matches[0])) {
-				continue;
+			$item = $this->addNavigationItem($pageIndex, $currentPage, $page, $whiteSpaceFreePermalink, $post->ID);
+			if ($item) {
+				$chapterNavigationItems[] = $item;
 			}
-
-			$chapterPage = $pageIndex + 1;
-			$chapterUrl = null;
-			if ($chapterPage !== $currentPage) {
-				$chapterUrl = $chapterPage === 1 ? $whiteSpaceFreePermalink . '/' : $whiteSpaceFreePermalink . '/' . $chapterPage . '/';
-			}
-
-			$chapterNavigationItems[] = new ChapterNavigationItem(
-				trim(strip_tags($matches[0][0])),
-				apply_filters('long_read_plugin_chapter_url', $chapterUrl, $post->ID)
-			);
 		}
 		
 		return $chapterNavigationItems;

--- a/src/PageBreakChapterNavigation.php
+++ b/src/PageBreakChapterNavigation.php
@@ -4,13 +4,42 @@ namespace LongReadPlugin;
 
 class PageBreakChapterNavigation implements ChapterNavigationInterface
 {
+	
+	public function getPages(): array
+	{
+		global $post;
+		$fullContent = apply_filters('the_content', $post->post_content);
+		$pages = explode('<!--nextpage-->', $fullContent);
+		return $pages;
+	}
+
 	public function getItems(): array
 	{
+		global $post;
 		$chapterNavigationItems = [];
-		$chapterNavigationItems[] = new ChapterNavigationItem(
-			apply_filters('long_read_plugin_chapter_title', 'Chapter 1'),
-			apply_filters('long_read_plugin_chapter_url', '/chapter-1')
-		);
+		$currentPage = max(1, (int) get_query_var('page', 1));
+		$pages = $this->getPages();
+		$permalink = get_permalink($post);
+		$normalizedPermalink = rtrim((string) $permalink, '/');
+		foreach ($pages as $pageIndex => $page) {
+			$regexPattern = "~(<h([2-6]))(.*?>(.*)<\/h[2-6]>)~";
+			preg_match_all($regexPattern, $page, $matches);
+			if (empty($matches[0])) {
+				continue;
+			}
+
+			$chapterPage = $pageIndex + 1;
+			$chapterUrl = null;
+			if ($chapterPage !== $currentPage) {
+				$chapterUrl = $chapterPage === 1 ? $normalizedPermalink . '/' : $normalizedPermalink . '/' . $chapterPage . '/';
+			}
+
+			$chapterNavigationItems[] = new ChapterNavigationItem(
+				trim(strip_tags($matches[0][0])),
+				apply_filters('long_read_plugin_chapter_url', $chapterUrl, $post->ID)
+			);
+		}
+		
 		return $chapterNavigationItems;
 	}
 }

--- a/src/di.php
+++ b/src/di.php
@@ -3,8 +3,8 @@
 $registrar->addInstance(new \LongReadPlugin\PostType());
 $registrar->addInstance(new \LongReadPlugin\HeadingAnchors());
 $registrar->addInstance(new \LongReadPlugin\Navigation(
-	new \LongReadPlugin\HierarchicalChapterNavigation(),
-	new \LongReadPlugin\HierarchicalInPageNavigation()
+	new \LongReadPlugin\PageBreakChapterNavigation(),
+	new \LongReadPlugin\PageBreakInPageNavigation()
 ));
 $registrar->addInstance(new \LongReadPlugin\Options());
 $registrar->addInstance(new \LongReadPlugin\Template());


### PR DESCRIPTION
## Description of changes

Introduces chapter navigation for long read articles split by page breaks. Takes some of the functionality from in-page navigation and some from the PSAA approach to long reads.

One thing to consider is whether the amount of repetition now requires a refactor?

To test, add the page break classes to the Navigation instance in di.php
...

## Checklist
- [x] Changelog updated
- [ ] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
