### PR TITLE
Fix/psalm errors

### DIFF
--- a/script/test
+++ b/script/test
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # script/test: Run test suite and linters
 

--- a/src/PageBreakChapterNavigation.php
+++ b/src/PageBreakChapterNavigation.php
@@ -17,7 +17,7 @@ class PageBreakChapterNavigation implements ChapterNavigationInterface
 
 		$matches = [];
 		preg_match('~<h([1-6])[^>]*>(.*?)</h\1>~is', $page, $matches);
-		if (empty($matches[0])) {
+		if (!isset($matches[0]) || !is_string($matches[0]) || trim($matches[0]) === '') {
 			return null;
 		}
 

--- a/src/PageBreakInPageNavigation.php
+++ b/src/PageBreakInPageNavigation.php
@@ -61,7 +61,7 @@ class PageBreakInPageNavigation implements InPageNavigationInterface
 
 	public function getItems(): array
 	{
-		
+
 		$this->inPageNavItems = [];
 		$currentPageMarkup = $this->getCurrentPageMarkup();
 		$blocks = parse_blocks($currentPageMarkup);

--- a/src/PageBreakInPageNavigation.php
+++ b/src/PageBreakInPageNavigation.php
@@ -4,7 +4,7 @@ namespace LongReadPlugin;
 
 class PageBreakInPageNavigation implements InPageNavigationInterface
 {
-	/** @var array $inPageNavItems */
+	/** @var array<InPageNavigationItem> */
 	private $inPageNavItems = [];
 
 	private function findHeadingMarkup(string $markup): void
@@ -41,27 +41,31 @@ class PageBreakInPageNavigation implements InPageNavigationInterface
 		);
 	}
 
-	private function findHeadingBlocks(array $blocks): void
+	private function findHeadingBlocks(array $blocks): bool
 	{
+		$foundHeadings = false;
 		foreach ($blocks as $block) {
 			if ($block['blockName'] == 'core/heading'  && array_key_exists('attrs', $block) && (!isset($block['attrs']['level']) || $block['attrs']['level'] == 2)) {
 				if (empty(trim(strip_tags($block['innerHTML'])))) {
 					continue;
 				}
 				$this->inPageNavItems[] = $this->parseHeading($block["innerHTML"]);
+				$foundHeadings = true;
 			} elseif ($block['blockName'] == 'acf/group-block' || $block['blockName'] == 'core/group') {
-				$this->findHeadingBlocks($block['innerBlocks']);
+				$foundHeadings = $this->findHeadingBlocks($block['innerBlocks']) || $foundHeadings;
 			}
 		}
+
+		return $foundHeadings;
 	}
 
 	public function getItems(): array
 	{
+		
 		$this->inPageNavItems = [];
 		$currentPageMarkup = $this->getCurrentPageMarkup();
 		$blocks = parse_blocks($currentPageMarkup);
-		$this->findHeadingBlocks($blocks);
-		if (count($this->inPageNavItems) === 0) {
+		if (!$this->findHeadingBlocks($blocks)) {
 			$this->findHeadingMarkup($currentPageMarkup);
 		}
 		return $this->inPageNavItems;


### PR DESCRIPTION
## Description of changes

This PR fixes a couple of issues reported by Psalm. The first involves tightening a test for a nullable string.
The second was caused by Psalm being unable to infer the type of an array of custom objects. An attempt to count items in the array is replaced by a boolean value which records whether any items have been added to the array.
...

## Checklist
- [ ] Changelog updated
- [ ] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
