### PR TITLE
Prevent duplicate chapter title and first in-page nav item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Issue where first in-page nav item would duplicate the title of that chapter.
+
 ## [v3.0.0] - 2026-07-26
 
 ### Changed
 
 - Use custom classes for navigation data
-- Create interfaces for page navigation 
+- Create interfaces for page navigation
 - [BREAKING] default value for subItems in PageNavigation introduced as part of interface refactor
 - Create interface for parent title
 

--- a/spec/navigation.spec.php
+++ b/spec/navigation.spec.php
@@ -58,5 +58,50 @@ describe(LongReadPlugin\Navigation::class, function () {
 			expect($result[2]->title)->toEqual('Chapter Three');
 			expect($result[2]->url)->toEqual('http://chapter-three');
 		});
+
+		it('does not include in-page nav items where the first heading we found is being used as the page title', function () {
+			$this->chapterNavigation = Double::instance(['extends' => '\LongReadPlugin\MultipageChapterNavigation']);
+			$this->inPageNavigation = Double::instance(['extends' => '\LongReadPlugin\MultipageInPageNavigation']);
+			allow($this->chapterNavigation)->toReceive('getItems')->andReturn([
+				(object) [
+					'title' => 'Chapter One',
+					'url' => 'http://chapter-one'
+				],
+				(object) [
+					'title' => 'Duplicate Heading',
+					'url' => null
+				],
+				(object) [
+					'title' => 'Chapter Three',
+					'url' => 'http://chapter-three'
+				]
+			]);
+			allow($this->inPageNavigation)->toReceive('getItems')->andReturn([
+				(object) [
+					'title' => 'Duplicate Heading',
+					'id' => 'heading-one'
+				],
+				(object) [
+					'title' => 'Heading Two',
+					'id' => 'heading-two'
+				]
+			]);
+			$navigation = new LongReadPlugin\Navigation(
+				$this->chapterNavigation,
+				$this->inPageNavigation
+			);
+
+			$result = LongReadPlugin\Navigation::getItems();
+
+			expect(count($result))->toEqual(3);
+			expect($result[0]->title)->toEqual('Chapter One');
+			expect($result[0]->url)->toEqual('http://chapter-one');
+			expect($result[1]->title)->toEqual('Duplicate Heading');
+			expect(count($result[1]->subItems))->toEqual(1);
+			expect($result[1]->subItems[1]->title)->toEqual('Heading Two');
+			expect($result[1]->subItems[1]->id)->toEqual('heading-two');
+			expect($result[2]->title)->toEqual('Chapter Three');
+			expect($result[2]->url)->toEqual('http://chapter-three');
+		});
 	});
 });

--- a/src/Navigation.php
+++ b/src/Navigation.php
@@ -24,6 +24,10 @@ class Navigation
 		foreach ($chapterNavItems as $chapterNavItem) {
 			if ($chapterNavItem->url === null) {
 				$chapterNavItem->subItems = $inPageNavItems;
+				// Don't include in-page nav items where the heading we found is actually the chapter title
+				if (array_key_exists(0, $chapterNavItem->subItems) && $chapterNavItem->subItems[0]->title === $chapterNavItem->title) {
+					unset($chapterNavItem->subItems[0]);
+				}
 			}
 		}
 		return $chapterNavItems;


### PR DESCRIPTION
For page-break based long reads, we have to assume that the first heading block after a page break is the title of that page/chapter.

However, we assemble the in-page nav by getting all the h2 heading blocks within that chapter.

This meant that if the first heading after a page break was an h2, that heading would be used as both the title of the chapter in the side nav, and as the first in-page nav item of that chapter.

This change checks if the title of the first in-page nav item matches the chapter title, and if so, it removes that in-page nav item.

Resolves: https://github.com/dxw/long-read-plugin/issues/44

## How to test

1. Checkout the main branch
2. Create a page-break based long read, where the first heading block in the second page is an h2
3. Observe that that h2 is rendered in the side nav as both the title of that chapter and the first in-page nav item of that chapter
4. Checkout this branch
5. The heading should now only be used as the chapter title, and the in-page nav items should start with the second heading in the page

## Checklist
- [x] Changelog updated
- [ ] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
