### PR TITLE
Feature/support preview links for page breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Support for preview links in page-break based long reads.
+
 ## [v3.0.1] - 2026-07-16
 
 ### Fixed

--- a/spec/page_break_chapter_navigation.spec.php
+++ b/spec/page_break_chapter_navigation.spec.php
@@ -12,10 +12,11 @@ describe(\LongReadPlugin\PageBreakChapterNavigation::class, function () {
 	describe('::getItems()', function () {
 		beforeEach(function () {
 			global $post;
-			$post = (object) [
-				'ID' => 123,
-				'post_content' => '<h2>Chapter 1</h2><!--nextpage--><h2>Chapter 2</h2>'
-			];
+			$post = \Kahlan\Plugin\Double::instance([
+				'class' => 'WP_Post'
+			]);
+			$post->ID = 123;
+			$post->post_content =  '<h2>Chapter 1</h2><!--nextpage--><h2>Chapter 2</h2>';
 
 			allow('apply_filters')->toBeCalled()->andRun(function ($filterName, $value) {
 				return $value;

--- a/spec/page_break_chapter_navigation.spec.php
+++ b/spec/page_break_chapter_navigation.spec.php
@@ -21,6 +21,7 @@ describe(\LongReadPlugin\PageBreakChapterNavigation::class, function () {
 				return $value;
 			});
 			allow('get_permalink')->toBeCalled()->andReturn('/long-read/');
+			allow('is_preview')->toBeCalled()->andReturn(false);
 		});
 
 		it('returns an array of chapter navigation items', function () {
@@ -58,6 +59,31 @@ describe(\LongReadPlugin\PageBreakChapterNavigation::class, function () {
 			expect(count($result))->toEqual(2);
 			expect($result[0]->url)->toEqual('/long-read/');
 			expect($result[1]->url)->toBeNull();
+		});
+
+		context('view is a preview', function () {
+			it('returns preview URLs', function () {
+				$chapter1 = new \LongReadPlugin\ChapterNavigationItem('Chapter 1', null);
+				$chapter2 = new \LongReadPlugin\ChapterNavigationItem('Chapter 2', 'http://localhost/preview/2');
+				allow('get_query_var')->toBeCalled()->with('page', 1)->andReturn(1);
+				allow('is_preview')->toBeCalled()->andReturn(true);
+				allow('get_preview_post_link')->toBeCalled()->andRun(function ($postId, $args) {
+					return 'http://localhost/preview/' . $args['page'];
+				});
+
+				$result = $this->navigation->getItems();
+				expect($result)->toEqual([$chapter1, $chapter2]);
+			});
+			it('returns standard URLs if preview link is null', function () {
+				$chapter1 = new \LongReadPlugin\ChapterNavigationItem('Chapter 1', null);
+				$chapter2 = new \LongReadPlugin\ChapterNavigationItem('Chapter 2', '/long-read/2/');
+				allow('get_query_var')->toBeCalled()->with('page', 1)->andReturn(1);
+				allow('is_preview')->toBeCalled()->andReturn(true);
+				allow('get_preview_post_link')->toBeCalled()->andReturn(null);
+
+				$result = $this->navigation->getItems();
+				expect($result)->toEqual([$chapter1, $chapter2]);
+			});
 		});
 	});
 });

--- a/src/PageBreakChapterNavigation.php
+++ b/src/PageBreakChapterNavigation.php
@@ -34,9 +34,8 @@ class PageBreakChapterNavigation implements ChapterNavigationInterface
 		return $chapterUrl;
 	}
 
-	private function addNavigationItem(int $pageIndex, int $currentPage, string $page, string $permalink, int $postId): ?ChapterNavigationItem
+	private function createNavigationItem(int $pageIndex, int $currentPage, string $page, string $permalink, int $postId): ?ChapterNavigationItem
 	{
-
 		$title = $this->getChapterTitle($page);
 		if ($title === null) {
 			return null;
@@ -59,7 +58,7 @@ class PageBreakChapterNavigation implements ChapterNavigationInterface
 		$permalink = get_permalink($post);
 		$whiteSpaceFreePermalink = rtrim((string) $permalink, '/');
 		foreach ($pages as $pageIndex => $page) {
-			$item = $this->addNavigationItem($pageIndex, $currentPage, $page, $whiteSpaceFreePermalink, $post->ID);
+			$item = $this->createNavigationItem($pageIndex, $currentPage, $page, $whiteSpaceFreePermalink, $post->ID);
 			if ($item) {
 				$chapterNavigationItems[] = $item;
 			}

--- a/src/PageBreakChapterNavigation.php
+++ b/src/PageBreakChapterNavigation.php
@@ -4,11 +4,9 @@ namespace LongReadPlugin;
 
 class PageBreakChapterNavigation implements ChapterNavigationInterface
 {
-	private function getPages(): array
+	private function getPages(\WP_Post $post): array
 	{
-		global $post;
-		$fullContent = $post->post_content;
-		$pages = explode('<!--nextpage-->', $fullContent);
+		$pages = explode('<!--nextpage-->', $post->post_content);
 		return $pages;
 	}
 
@@ -42,7 +40,7 @@ class PageBreakChapterNavigation implements ChapterNavigationInterface
 		global $post;
 		$chapterNavigationItems = [];
 		$currentPage = max(1, (int) get_query_var('page', 1));
-		$pages = $this->getPages();
+		$pages = $this->getPages($post);
 		$permalink = get_permalink($post);
 		$whiteSpaceFreePermalink = rtrim((string) $permalink, '/');
 		foreach ($pages as $pageIndex => $page) {

--- a/src/PageBreakChapterNavigation.php
+++ b/src/PageBreakChapterNavigation.php
@@ -10,15 +10,18 @@ class PageBreakChapterNavigation implements ChapterNavigationInterface
 		return $pages;
 	}
 
-	private function addNavigationItem(int $pageIndex, int $currentPage, string $page, string $permalink, int $postId): ?ChapterNavigationItem
+	private function getChapterTitle(string $page): ?string
 	{
-
 		$matches = [];
 		preg_match('~<h([1-6])[^>]*>(.*?)</h\1>~is', $page, $matches);
 		if (!isset($matches[0]) || !is_string($matches[0]) || trim($matches[0]) === '') {
 			return null;
 		}
+		return trim(strip_tags($matches[0]));
+	}
 
+	private function getChapterUrl(int $pageIndex, int $currentPage, string $permalink, int $postId): ?string
+	{
 		$chapterPage = $pageIndex + 1;
 		$chapterUrl = null;
 		if ($chapterPage !== $currentPage) {
@@ -28,10 +31,22 @@ class PageBreakChapterNavigation implements ChapterNavigationInterface
 				$chapterUrl = $previewLink ?? $chapterUrl;
 			}
 		}
+		return $chapterUrl;
+	}
+
+	private function addNavigationItem(int $pageIndex, int $currentPage, string $page, string $permalink, int $postId): ?ChapterNavigationItem
+	{
+
+		$title = $this->getChapterTitle($page);
+		if ($title === null) {
+			return null;
+		}
+
+		$url = $this->getChapterUrl($pageIndex, $currentPage, $permalink, $postId);
 
 		return new ChapterNavigationItem(
-			trim(strip_tags($matches[0])),
-			apply_filters('long_read_plugin_chapter_url', $chapterUrl, $postId)
+			$title,
+			apply_filters('long_read_plugin_chapter_url', $url, $postId)
 		);
 	}
 

--- a/src/PageBreakChapterNavigation.php
+++ b/src/PageBreakChapterNavigation.php
@@ -25,6 +25,10 @@ class PageBreakChapterNavigation implements ChapterNavigationInterface
 		$chapterUrl = null;
 		if ($chapterPage !== $currentPage) {
 			$chapterUrl = $chapterPage === 1 ? $permalink . '/' : $permalink . '/' . $chapterPage . '/';
+			if (is_preview()) {
+				$previewLink = get_preview_post_link($postId, ['page' => $chapterPage]);
+				$chapterUrl = $previewLink ?? $chapterUrl;
+			}
 		}
 
 		return new ChapterNavigationItem(


### PR DESCRIPTION
## Description of changes

This PR adds support for previewing a draft page-break based long read.

Before, the chapter navigation, and pagination links, would not render correctly. Now, they will.

It also does some minor refactoring to make the `PageBreakChapterNavigation` class more readable.

## How to test

1. Spin up a site that uses this plugin (e.g. UKSS), and checkout this branch
1. Ensure you have page-break based long reads activated, by setting the `DXW_PAGE_BREAK_LONG_READ` constant to `true`.
1. Create a long-read item that uses page breaks, and save it as draft
1. Preview the long read, and confirm that chapter navigation and pagination links function correctly

## Checklist
- [x] Changelog updated
- [ ] If new release: major version tag to be bumped after release (see [docs](../README.md#changelog-and-versioning))
