### PR TITLE
Fix state bug in multipage navigation item retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Bug that could result in `MultipageInPageNavigation::getItems()` returning duplicates if called repeatedly
+
 ## [v3.1.0] - 2026-07-17
 
 ### Added

--- a/spec/multipage_in_page_navigation.spec.php
+++ b/spec/multipage_in_page_navigation.spec.php
@@ -121,5 +121,24 @@ describe(LongReadPlugin\MultipageInPageNavigation::class, function () {
 			expect($result[0]->title)->toEqual("First heading");
 			expect($result[0]->id)->toEqual('first-heading');
 		});
+
+		it('returns the same items when called twice on the same instance', function () {
+			global $post;
+			$post->post_content = 'Some content';
+			$blocks = [
+				[
+					'blockName' => 'core/heading',
+					'attrs' => [],
+					'innerHTML' => '<h2 id="first-heading">First heading</h2>'
+				],
+			];
+			allow('parse_blocks')->toBeCalled()->andReturn($blocks);
+
+			$firstResult = $this->inPageNavigation->getItems();
+			$secondResult = $this->inPageNavigation->getItems();
+
+			expect(count($firstResult))->toEqual(1);
+			expect(count($secondResult))->toEqual(1);
+		});
 	});
 });

--- a/src/MultipageInPageNavigation.php
+++ b/src/MultipageInPageNavigation.php
@@ -36,6 +36,7 @@ class MultipageInPageNavigation implements InPageNavigationInterface
 
 	public function getItems(): array
 	{
+		$this->inPageNavItems = [];
 		global $post;
 		$blocks = parse_blocks($post->post_content);
 		$this->findHeadingBlocks($blocks);


### PR DESCRIPTION
This PR fixes a bug in the multipage navigation functionality by ensuring that repeated calls to `MultipageInPageNavigation::getItems()` return consistent results.

Before: `getItems()` would duplicate the items set if called more than once on the same instance. This could result in navigation rendering incorrectly.
Now: it always only returns the single correct set of items.

This PR was co-authored with CoPilot.

## How to test

1. Spin up a site that uses the parent/child structure for long reads
2. Checkout the main branch of this plugin
3. Modify the `LongReadPlugin\Navigation::getItems()` method so it repeatedly gets the in-page items, e.g.
```
public static function getItems(): array
	{
		if (!isset(static::$chapterNavigation) || !isset(static::$inPageNavigation)) {
			return [];
		}
		$chapterNavItems = static::$chapterNavigation->getItems();
		$inPageNavItems = static::$inPageNavigation->getItems();
		$inPageNavItems = static::$inPageNavigation->getItems();
		$inPageNavItems = static::$inPageNavigation->getItems();
...
```
4. Confirm that this results in duplicate sets of in-page navigation items
5. Checkout this branch and make the same modification to that file
6. Confirm that navigation still renders correctly in the front-end, and no other changes are visible.